### PR TITLE
Remove final from InvoiceSequence

### DIFF
--- a/src/Entity/InvoiceSequence.php
+++ b/src/Entity/InvoiceSequence.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace Sylius\InvoicingPlugin\Entity;
 
-final class InvoiceSequence implements InvoiceSequenceInterface
+/** @final */
+class InvoiceSequence implements InvoiceSequenceInterface
 {
     /** @var mixed */
     protected $id;


### PR DESCRIPTION
It results in bug in application using this plugin :(

```
Unable to create a proxy for a final class "Sylius\InvoicingPlugin\Entity\InvoiceSequence"
```