### PR TITLE
React with OrderPlaced event on doctrine event instead of SM callback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ before_script:
     - (cd tests/Application && bin/console assets:install web --env=test -vvv)
     - (cd tests/Application && yarn build)
 
+    # Running fixtures to be sure they're not failing
+    - (cd tests/Application && bin/console sylius:fixtures:load -n --env test)
+
     # Configure display
     - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1680x1050x16
     - export DISPLAY=:99

--- a/spec/EventProducer/OrderPlacedProducerSpec.php
+++ b/spec/EventProducer/OrderPlacedProducerSpec.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace spec\Sylius\InvoicingPlugin\EventProducer;
 
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use PhpSpec\ObjectBehavior;
 use Prooph\ServiceBus\EventBus;
 use Prophecy\Argument;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\InvoicingPlugin\DateTimeProvider;
 use Sylius\InvoicingPlugin\Event\OrderPlaced;
 
@@ -18,15 +20,19 @@ final class OrderPlacedProducerSpec extends ObjectBehavior
         $this->beConstructedWith($eventBus, $dateTimeProvider);
     }
 
-    function it_dispatches_an_order_placed_event_for_an_order(
+    function it_dispatches_an_order_placed_event_for_persited_order(
         EventBus $eventBus,
         DateTimeProvider $dateTimeProvider,
+        LifecycleEventArgs $event,
         OrderInterface $order,
         \DateTime $dateTime
     ): void {
         $dateTimeProvider->__invoke()->willReturn($dateTime);
 
+        $event->getEntity()->willReturn($order);
+
         $order->getNumber()->willReturn('000666');
+        $order->getCheckoutState()->willReturn(OrderCheckoutStates::STATE_COMPLETED);
 
         $eventBus
             ->dispatch(Argument::that(function (OrderPlaced $event) use ($dateTime): bool {
@@ -38,6 +44,58 @@ final class OrderPlacedProducerSpec extends ObjectBehavior
             ->shouldBeCalled()
         ;
 
-        $this($order);
+        $this->postPersist($event);
+    }
+
+    function it_dispatches_an_order_placed_event_for_updated_order(
+        EventBus $eventBus,
+        DateTimeProvider $dateTimeProvider,
+        LifecycleEventArgs $event,
+        OrderInterface $order,
+        \DateTime $dateTime
+    ): void {
+        $dateTimeProvider->__invoke()->willReturn($dateTime);
+
+        $event->getEntity()->willReturn($order);
+
+        $order->getNumber()->willReturn('000666');
+        $order->getCheckoutState()->willReturn(OrderCheckoutStates::STATE_COMPLETED);
+
+        $eventBus
+            ->dispatch(Argument::that(function (OrderPlaced $event) use ($dateTime): bool {
+                return
+                    $event->orderNumber() === '000666' &&
+                    $event->date() === $dateTime->getWrappedObject()
+                ;
+            }))
+            ->shouldBeCalled()
+        ;
+
+        $this->postUpdate($event);
+    }
+
+    function it_does_nothing_if_event_entity_is_not_order(EventBus $eventBus, LifecycleEventArgs $event): void
+    {
+        $event->getEntity()->willReturn('notAnOrder', 'notAnOrder');
+
+        $eventBus->dispatch(Argument::any())->shouldNotBeCalled();
+
+        $this->postPersist($event);
+        $this->postUpdate($event);
+    }
+
+    function it_does_nothing_if_order_is_not_completed(
+        EventBus $eventBus,
+        LifecycleEventArgs $event,
+        OrderInterface $order
+    ): void {
+        $event->getEntity()->willReturn($order, $order);
+
+        $order->getCheckoutState()->willReturn(OrderCheckoutStates::STATE_CART, OrderCheckoutStates::STATE_ADDRESSED);
+
+        $eventBus->dispatch(Argument::any())->shouldNotBeCalled();
+
+        $this->postPersist($event);
+        $this->postUpdate($event);
     }
 }

--- a/src/DependencyInjection/SyliusInvoicingExtension.php
+++ b/src/DependencyInjection/SyliusInvoicingExtension.php
@@ -37,17 +37,6 @@ final class SyliusInvoicingExtension extends AbstractResourceExtension implement
         }
 
         $container->prependExtensionConfig('winzou_state_machine', [
-            'sylius_order' => [
-                'callbacks' => [
-                    'after' => [
-                        'sylius_invoicing_plugin_order_created_producer' => [
-                            'on' => ['create'],
-                            'do' => ['@Sylius\InvoicingPlugin\EventProducer\OrderPlacedProducer', '__invoke'],
-                            'args' => ['object'],
-                        ],
-                    ],
-                ],
-            ],
             'sylius_payment' => [
                 'callbacks' => [
                     'after' => [

--- a/src/EventProducer/OrderPlacedProducer.php
+++ b/src/EventProducer/OrderPlacedProducer.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Sylius\InvoicingPlugin\EventProducer;
 
+use Doctrine\ORM\Event\LifecycleEventArgs;
 use Prooph\ServiceBus\EventBus;
 use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\OrderCheckoutStates;
 use Sylius\InvoicingPlugin\DateTimeProvider;
 use Sylius\InvoicingPlugin\Event\OrderPlaced;
 
@@ -23,8 +25,27 @@ final class OrderPlacedProducer
         $this->dateTimeProvider = $dateTimeProvider;
     }
 
-    public function __invoke(OrderInterface $order): void
+    public function postPersist(LifecycleEventArgs $event): void
     {
+        $this->dispatchOrderPlacedEventIfNecessary($event);
+    }
+
+    public function postUpdate(LifecycleEventArgs $event): void
+    {
+        $this->dispatchOrderPlacedEventIfNecessary($event);
+    }
+
+    private function dispatchOrderPlacedEventIfNecessary(LifecycleEventArgs $event): void
+    {
+        $order = $event->getEntity();
+
+        if (
+            !$order instanceof OrderInterface ||
+            $order->getCheckoutState() !== OrderCheckoutStates::STATE_COMPLETED
+        ) {
+            return;
+        }
+
         $this->eventBus->dispatch(
             new OrderPlaced($order->getNumber(), $this->dateTimeProvider->__invoke())
         );

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -20,6 +20,8 @@
         <service id="Sylius\InvoicingPlugin\EventProducer\OrderPlacedProducer" public="true">
             <argument type="service" id="sylius_invoicing.event_bus" />
             <argument type="service" id="Sylius\InvoicingPlugin\DateTimeProvider" />
+            <tag name="doctrine.event_listener" event="postPersist" />
+            <tag name="doctrine.event_listener" event="postUpdate" />
         </service>
 
         <service id="Sylius\InvoicingPlugin\EventProducer\OrderPaymentPaidProducer" public="true">

--- a/tests/Application/.gitignore
+++ b/tests/Application/.gitignore
@@ -4,6 +4,11 @@
 !/var/.gitkeep
 
 /web/*
+!/web/media/
+/web/media/*
+!/web/media/image/
+/web/media/image/*
+!/web/media/image/.gitkeep
 !/web/app.php
 !/web/app_dev.php
 !/web/app_test.php


### PR DESCRIPTION
Introduced in https://github.com/Sylius/InvoicingPlugin/pull/33

The problem was when fixtures were used, Order was not yet persisted, then it could not be fetched from the repository. The best solution right now is reacting on doctrine events (:/) instead of state machine callback. Maybe we'll figure out better solution in the future.