### PR TITLE
Fixed currency symbols rendering with UTF-8 encoding

### DIFF
--- a/src/Resources/views/Invoice/Download/pdf.html.twig
+++ b/src/Resources/views/Invoice/Download/pdf.html.twig
@@ -1,6 +1,9 @@
 {% set shopBillingData = sylius.channel.billingData %}
 
 <html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+    </head>
     <body>
         <h1>{{ 'sylius_invoicing_plugin.ui.invoice'|trans }} {{ invoice.number }}</h1>
         <p>{{ 'sylius_invoicing_plugin.ui.order_number'|trans }}: {{ invoice.orderNumber }}</p>


### PR DESCRIPTION
Some currency symbols are rendered weirdly if you don't specify the charset in the rendered HTML page. (eg. the € symbol)