### PR TITLE
Remove hardcoded binary path for wkhtmltopdf

### DIFF
--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -7,8 +7,6 @@ sylius_mailer:
 knp_snappy:
     pdf:
         enabled: true
-        binary: /usr/local/bin/wkhtmltopdf
-        options: []
 
 prooph_service_bus:
     event_buses:


### PR DESCRIPTION
KnpSnappyBundle already provides a more sensible default: https://github.com/KnpLabs/KnpSnappyBundle/blob/v1.5.2/DependencyInjection/Configuration.php#L41