### PR TITLE
Make plugin possible to be installed with SymfonyFlex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "sylius/invoicing-plugin",
-    "type": "sylius-plugin",
+    "type": "symfony-bundle",
+    "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "invoicing"],
     "description": "Invoicing plugin for Sylius.",
     "license": "MIT",
     "require": {
         "php": "^7.2",
 
         "sylius/sylius": "~1.3.0",
-        "symfony/symfony": "^3.4|^4.1",
         "prooph/service-bus": "^6.2",
         "prooph/service-bus-symfony-bundle": "^0.7.0",
         "ramsey/uuid": "^3.7",
@@ -29,7 +29,13 @@
         "phpspec/phpspec": "^4.0",
         "phpstan/phpstan-shim": "^0.9.2",
         "phpunit/phpunit": "^6.5",
-        "sylius-labs/coding-standard": "^2.0"
+        "sylius-labs/coding-standard": "^2.0",
+        "symfony/browser-kit": "^3.4|^4.1",
+        "symfony/debug-bundle": "^3.4|^4.1",
+        "symfony/dotenv": "^3.4|^4.1",
+        "symfony/intl": "^3.4|^4.1",
+        "symfony/web-profiler-bundle": "^3.4|^4.1",
+        "symfony/web-server-bundle": "^3.4|^4.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Following an approach proposed in https://github.com/Sylius/RefundPlugin/pull/69 and in https://github.com/Sylius/PluginSkeleton/pull/123/files