### PR TITLE
Bring back "sylius-plugin" composer type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "sylius/invoicing-plugin",
-    "type": "symfony-bundle",
+    "type": "sylius-plugin",
     "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "invoicing"],
     "description": "Invoicing plugin for Sylius.",
     "license": "MIT",


### PR DESCRIPTION
**SymfonyFlex** has now support for `sylius-plugin` as a synonymous of `symfony-bundle` :)