### PR TITLE
Change migrations namespace

### DIFF
--- a/migrations/Version20180626120743.php
+++ b/migrations/Version20180626120743.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180711070226.php
+++ b/migrations/Version20180711070226.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180711084815.php
+++ b/migrations/Version20180711084815.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180801083047.php
+++ b/migrations/Version20180801083047.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/migrations/Version20180826064735.php
+++ b/migrations/Version20180826064735.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Sylius\Migrations;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;


### PR DESCRIPTION
Namespace migrations in Sylius-Standard is now `DoctrineMigrations` (see https://github.com/Sylius/Sylius-Standard/blob/master/config/packages/doctrine_migrations.yaml#L5), therefore we should follow this convention