### PR TITLE
Add messages for fr locale

### DIFF
--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -1,0 +1,17 @@
+sylius_invoicing_plugin:
+    ui:
+        billing_data: 'Données de facturation'
+        buyer: 'Acheteur'
+        download_invoice: 'Télécharger'
+        invoice: 'Facture'
+        invoice_id: 'ID de facture'
+        invoice_number: 'Numéro de facture'
+        invoices: 'Factures'
+        issued_at: 'Émise le'
+        issued_for_order: 'Émise pour la commande'
+        issued_from: 'Émise de'
+        manage_invoices: 'Gérez vos factures'
+        order_number: 'Numéro de commande'
+        resend_invoice: 'Réenvoyer'
+        seller: 'Vendeur'
+        tax_id: 'ID de taxe'


### PR DESCRIPTION
Fix #44

There is an issue with the colon in Sylius. In French we need to have a **non-breaking space** before it. That's why it should be in the message itself and not in the code.
An example:
https://github.com/Sylius/InvoicingPlugin/blob/e91c56d357736df712ee0980261a914c04fc38a4/src/Resources/views/Invoice/Download/pdf.html.twig#L10
WDYT?