### PR TITLE
Force file extension

### DIFF
--- a/src/Ui/Action/DownloadInvoiceAction.php
+++ b/src/Ui/Action/DownloadInvoiceAction.php
@@ -52,7 +52,7 @@ final class DownloadInvoiceAction
         ));
 
         $response->headers->add(['Content-Type' => 'application/pdf']);
-        $response->headers->add(['Content-Disposition' => $response->headers->makeDisposition('attachment', $filename)]);
+        $response->headers->add(['Content-Disposition' => $response->headers->makeDisposition('attachment', $filename.'.pdf')]);
 
         return $response;
     }


### PR DESCRIPTION
In order to be correctly opened by user (and not be asked with wich program he wants to open it), it's useful to force file extension for download.