### PR TITLE
Resolving suites/tags conflict

### DIFF
--- a/features/managing_channels/editing_shop_billing_data_on_channel.feature
+++ b/features/managing_channels/editing_shop_billing_data_on_channel.feature
@@ -1,4 +1,4 @@
-@managing_channels @ui
+@invoicing_managing_channels @ui
 Feature: Editing shop billing data on channel
     In order to have proper shop billing data on invoices
     As an Administrator

--- a/tests/Behat/Resources/suites/admin/managing_channels.yml
+++ b/tests/Behat/Resources/suites/admin/managing_channels.yml
@@ -1,6 +1,6 @@
 default:
     suites:
-        ui_managing_channels:
+        ui_invoicing_managing_channels:
             contexts_services:
                 - sylius.behat.context.hook.doctrine_orm
 
@@ -25,4 +25,4 @@ default:
 
                 - Tests\Sylius\InvoicingPlugin\Behat\Context\Ui\Admin\ManagingChannelsContext
             filters:
-                tags: "@managing_channels && @ui"
+                tags: "@invoicing_managing_channels && @ui"


### PR DESCRIPTION
It occurred that there already is a `@managing_channels` tag in Sylius/Sylius as well as `ui_managing_channels` suite. Therefore, channel-related tests from InvoicingPlugin were loaded by suite used by Sylius/Sylius and fail due to undefined steps. 

The problem occurred only while running InvocingPlugin tests with Sylius/Sylius installed as a dependency.