### PR TITLE
Make all plugin templates possible to overwrite

### DIFF
--- a/src/Resources/config/app/routing/admin_invoicing.yml
+++ b/src/Resources/config/app/routing/admin_invoicing.yml
@@ -21,7 +21,7 @@ sylius_invoicing_plugin_admin_invoice_show:
         _sylius:
             section: admin
             permission: true
-            template: SyliusInvoicingPlugin:Invoice:show.html.twig
+            template: "@SyliusInvoicingPlugin/Invoice/show.html.twig"
 
 sylius_invoicing_plugin_admin_invoice_download:
     path: /invoices/{id}/download

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -2,7 +2,7 @@ sylius_mailer:
     emails:
         invoice_generated:
             subject: sylius.emails.invoice_generated.subject
-            template: "@SyliusInvoicingPlugin/Resources/views/Invoice/Email/invoiceGenerated.html.twig"
+            template: "@SyliusInvoicingPlugin/Invoice/Email/invoiceGenerated.html.twig"
 
 knp_snappy:
     pdf:

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -101,7 +101,7 @@
             <argument type="service" id="templating.engine.twig" />
             <argument type="service" id="knp_snappy.pdf" />
             <argument type="service" id="file_locator" />
-            <argument>@SyliusInvoicingPlugin/Resources/views/Invoice/Download/pdf.html.twig</argument>
+            <argument>@SyliusInvoicingPlugin/Invoice/Download/pdf.html.twig</argument>
             <argument>@SyliusInvoicingPlugin/Resources/assets/sylius-logo.png</argument>
         </service>
 


### PR DESCRIPTION
Fixes https://github.com/Sylius/InvoicingPlugin/issues/84

Ok, I think we've finally managed (kinda) to resolve this problem 😄 There are some problems in Sylius (or even in Symfony itself) with overwriting templates, that are not configured with a one, specific path style. It should always follow `@SyliusTestPlugin/Catalog/templateName.html.twig` convention - and as you can see, there were some other conventions used :) It would be good if someone could test these changes before merging (cc @itwhy), but I've tested all plugin templates on a fresh Sylius-Standard application and it worked 🚀 