### PR TITLE
Fix invalid configuration framework.messenger config messenger error

### DIFF
--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -13,6 +13,7 @@ knp_snappy:
 
 framework:
     messenger:
+        default_bus: sylius_invoicing_plugin.command_bus
         buses:
             sylius_invoicing_plugin.command_bus: ~
             sylius_invoicing_plugin.event_bus:


### PR DESCRIPTION
Invalid configuration for path "framework.messenger": You must specify the "default_bus" if you define more than one bus