### PR TITLE
Add flysystem to store generated invoice PDFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,27 @@ The dot's color is dependant on a property defined on Channel entity or, if not 
 
 Like any other parameter, `default_channel_color` can also be overwritten in your `config.yml` file.
 
+## Using different filesystem adapters
+
+You can change the adapter used by the invoice filesystem to generate your PDF files directly in AwsS3, AzureBlobStorage, SFTP, etc.
+
+First you need to install the corresponding adapter for your filesystem via `composer require`. Go to [this list](https://github.com/1up-lab/OneupFlysystemBundle/blob/master/Resources/doc/index.md#step-1-download-the-bundle) on the OneUpFlysystemBundle repository to see the available adapters and follow the links to the adapter configurations in [this section](https://github.com/1up-lab/OneupFlysystemBundle/blob/master/Resources/doc/index.md#step3-configure-your-filesystems).
+
+If you want your PDF files to be stored in a local directory you can leverage the `LocalAdapter` with the following adapter configuration in your `oneup_flysystem.yaml` without having to install an additional adapter:
+
+```
+oneup_flysystem:
+    adapters:
+        invoice:
+            local:
+                directory: '%kernel.project_dir%/var/storage/invoice'
+
+    filesystems:
+        invoice:
+            adapter: invoice
+            alias: League\Flysystem\Filesystem
+```
+
 ## Fixtures
 
 You can add `ShopBillingData` fixtures into a yaml to add Channel ShopBillingData info to your installation.

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,8 @@
     "require": {
         "php": "^7.2",
         "knplabs/knp-snappy-bundle": "^1.5",
+        "league/flysystem-memory": "^1.0",
+        "oneup/flysystem-bundle": "^3.4",
         "ramsey/uuid": "^3.7",
         "sylius/grid-bundle": "^1.7",
         "sylius/resource-bundle": "^1.6",

--- a/src/DependencyInjection/SyliusInvoicingExtension.php
+++ b/src/DependencyInjection/SyliusInvoicingExtension.php
@@ -7,9 +7,10 @@ namespace Sylius\InvoicingPlugin\DependencyInjection;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
-final class SyliusInvoicingExtension extends AbstractResourceExtension
+final class SyliusInvoicingExtension extends AbstractResourceExtension implements PrependExtensionInterface
 {
     public function load(array $config, ContainerBuilder $container): void
     {
@@ -19,5 +20,24 @@ final class SyliusInvoicingExtension extends AbstractResourceExtension
         $this->registerResources('sylius_invoicing_plugin', 'doctrine/orm', $config['resources'], $container);
 
         $loader->load('services.xml');
+    }
+
+    public function prepend(ContainerBuilder $container): void
+    {
+        $config = [
+            'adapters' => [
+                'invoice' => [
+                        'memory' => null,
+                ],
+            ],
+            'filesystems' => [
+                'invoice' => [
+                    'adapter' => 'invoice',
+                    'alias' => 'League\Flysystem\Filesystem',
+                ],
+            ],
+        ];
+
+        $container->prependExtensionConfig('oneup_flysystem', $config);
     }
 }

--- a/src/Email/InvoiceEmailSender.php
+++ b/src/Email/InvoiceEmailSender.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Sylius\InvoicingPlugin\Email;
 
+use League\Flysystem\FilesystemInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
 use Sylius\InvoicingPlugin\Filesystem\TemporaryFilesystem;
@@ -20,27 +21,47 @@ final class InvoiceEmailSender implements InvoiceEmailSenderInterface
     /** @var TemporaryFilesystem */
     private $temporaryFilesystem;
 
+    /** @var FilesystemInterface */
+    private $invoiceFilesystem;
+
     public function __construct(
         SenderInterface $emailSender,
-        InvoicePdfFileGeneratorInterface $invoicePdfFileGenerator
+        InvoicePdfFileGeneratorInterface $invoicePdfFileGenerator,
+        FilesystemInterface $invoiceFilesystem
     ) {
         $this->emailSender = $emailSender;
         $this->invoicePdfFileGenerator = $invoicePdfFileGenerator;
         $this->temporaryFilesystem = new TemporaryFilesystem();
+        $this->invoiceFilesystem = $invoiceFilesystem;
     }
 
     public function sendInvoiceEmail(
         InvoiceInterface $invoice,
         string $customerEmail
     ): void {
-        $pdfInvoice = $this->invoicePdfFileGenerator->generate($invoice);
+        $pdfInvoiceFilename = $this->invoicePdfFileGenerator->buildFilenameForInvoice($invoice);
+
+        if (!$this->invoiceFilesystem->has($pdfInvoiceFilename)) {
+            $pdfInvoice = $this->invoicePdfFileGenerator->generate($invoice);
+
+            $this->invoiceFilesystem->put(
+                $pdfInvoice->filename(),
+                $pdfInvoice->content()
+            );
+        }
+
+        $pdfInvoiceFile = $this->invoiceFilesystem->read($pdfInvoiceFilename);
+
+        if ($pdfInvoiceFile === false) {
+            return;
+        }
 
         // Since Sylius' Mailer does not support sending attachments which aren't real files
         // we have to simulate the file being on the local filesystem, so that we save the PDF,
         // run the callable and delete it when the callable is finished.
         $this->temporaryFilesystem->executeWithFile(
-            $pdfInvoice->filename(),
-            $pdfInvoice->content(),
+            $pdfInvoiceFilename,
+            $pdfInvoiceFile,
             function (string $filepath) use ($invoice, $customerEmail): void {
                 $this->emailSender->send(Emails::INVOICE_GENERATED, [$customerEmail], ['invoice' => $invoice], [$filepath]);
             }

--- a/src/Generator/InvoicePdfFileGenerator.php
+++ b/src/Generator/InvoicePdfFileGenerator.php
@@ -45,8 +45,7 @@ final class InvoicePdfFileGenerator implements InvoicePdfFileGeneratorInterface
 
     public function generate(InvoiceInterface $invoice): InvoicePdf
     {
-        /** @var string $filename */
-        $filename = str_replace('/', '_', $invoice->number()) . self::FILE_EXTENSION;
+        $filename = $this->buildFilenameForInvoice($invoice);
 
         $pdf = $this->pdfGenerator->getOutputFromHtml(
             $this->templatingEngine->render($this->template, [
@@ -57,5 +56,10 @@ final class InvoicePdfFileGenerator implements InvoicePdfFileGeneratorInterface
         );
 
         return new InvoicePdf($filename, $pdf);
+    }
+
+    public function buildFilenameForInvoice(InvoiceInterface $invoice): string
+    {
+        return str_replace('/', '_', $invoice->number()) . self::FILE_EXTENSION;
     }
 }

--- a/src/Generator/InvoicePdfFileGeneratorInterface.php
+++ b/src/Generator/InvoicePdfFileGeneratorInterface.php
@@ -10,4 +10,6 @@ use Sylius\InvoicingPlugin\Model\InvoicePdf;
 interface InvoicePdfFileGeneratorInterface
 {
     public function generate(InvoiceInterface $invoice): InvoicePdf;
+
+    public function buildFilenameForInvoice(InvoiceInterface $invoice): string;
 }

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,6 +15,7 @@
         <service id="sylius_invoicing_plugin.email.invoice_email_sender" class="Sylius\InvoicingPlugin\Email\InvoiceEmailSender">
             <argument type="service" id="sylius.email_sender" />
             <argument type="service" id="sylius_invoicing_plugin.generator.invoice_pdf_file" />
+            <argument type="service" id="oneup_flysystem.invoice_filesystem" />
         </service>
 
         <service id="sylius_invoicing_plugin.command_handler.send_invoice_email" class="Sylius\InvoicingPlugin\CommandHandler\SendInvoiceEmailHandler">

--- a/src/Resources/config/services/actions.xml
+++ b/src/Resources/config/services/actions.xml
@@ -8,6 +8,7 @@
             <argument type="service" id="sylius_invoicing_plugin.custom_repository.invoice" />
             <argument type="service" id="security.authorization_checker" />
             <argument type="service" id="sylius_invoicing_plugin.generator.invoice_pdf_file" />
+            <argument type="service" id="oneup_flysystem.invoice_filesystem" />
         </service>
 
         <service id="sylius_invoicing_plugin.ui.action.resend_invoice" class="Sylius\InvoicingPlugin\Ui\Action\Admin\ResendInvoiceAction">

--- a/src/Resources/config/services/generators.xml
+++ b/src/Resources/config/services/generators.xml
@@ -35,6 +35,8 @@
             <argument type="service" id="sylius_invoicing_plugin.custom_repository.invoice" />
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius_invoicing_plugin.generator.invoice" />
+            <argument type="service" id="sylius_invoicing_plugin.generator.invoice_pdf_file" />
+            <argument type="service" id="oneup_flysystem.invoice_filesystem" />
         </service>
 
         <service id="sylius_invoicing_plugin.creator.mass_invoices" class="Sylius\InvoicingPlugin\Creator\MassInvoicesCreator">


### PR DESCRIPTION
This PR adds the functionality to automatically save the generated PDF invoice to a filesystem location and serve the generated file to users and admins so that is possible to ensure that everyone has the same file for their archives since it is currently possible that the invoice layout or language changed between the user receiving the file and an admin archiving it for example by  downloading it in the backend.

By default the filesystem location is defined as in memory so that the current behaviour of the plugin is maintained. I've added a section to the README.md with a configuration that changes the behaviour to use a local filesystem with the directory at `%kernel.project_dir%/var/storage/invoice` and an explanation on how to use other adapters.

See #180 for my initial post about this functionality for more details.

