### PR TITLE
[FIX] Unable to load Invoice correctly if the Invoice entity is extended

### DIFF
--- a/src/Repository/DoctrineInvoiceRepository.php
+++ b/src/Repository/DoctrineInvoiceRepository.php
@@ -17,10 +17,10 @@ final class DoctrineInvoiceRepository implements InvoiceRepository
     /** @var ObjectRepository */
     private $entityRepository;
 
-    public function __construct(EntityManagerInterface $entityManager)
+    public function __construct(EntityManagerInterface $entityManager, string $className)
     {
         $this->entityManager = $entityManager;
-        $this->entityRepository = $entityManager->getRepository(Invoice::class);
+        $this->entityRepository = $entityManager->getRepository($className);
     }
 
     public function get(string $invoiceId): InvoiceInterface

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -10,7 +10,9 @@
 
         <service id="sylius_invoicing_plugin.date_time_provider" class="Sylius\InvoicingPlugin\SystemDateTimeProvider" />
 
-        <service id="sylius_invoicing_plugin.custom_repository.invoice" class="Sylius\InvoicingPlugin\Repository\DoctrineInvoiceRepository" />
+        <service id="sylius_invoicing_plugin.custom_repository.invoice" class="Sylius\InvoicingPlugin\Repository\DoctrineInvoiceRepository">
+            <argument>%sylius_invoicing_plugin.model.invoice.class%</argument>
+        </service>
 
         <service id="sylius_invoicing_plugin.email.invoice_email_sender" class="Sylius\InvoicingPlugin\Email\InvoiceEmailSender">
             <argument type="service" id="sylius.email_sender" />


### PR DESCRIPTION
When I extend the Invoice entity, the doctrine ORM cannot load correctly all related data.

To solve this issue, I have copied in my project the custom repository with this change.