### PR TITLE
Fix Doctrine/Migrations configuration

### DIFF
--- a/src/DependencyInjection/SyliusInvoicingExtension.php
+++ b/src/DependencyInjection/SyliusInvoicingExtension.php
@@ -28,10 +28,15 @@ final class SyliusInvoicingExtension extends AbstractResourceExtension implement
             return;
         }
 
+        $doctrineConfig = $container->getExtensionConfig('doctrine_migrations');
+        $migrationsPath = (array) \array_pop($doctrineConfig)['migrations_paths'];
         $container->prependExtensionConfig('doctrine_migrations', [
-            'migrations_paths' => [
-                'Sylius\InvoicingPlugin\Migrations' => '@SyliusInvoicingPlugin/Migrations',
-            ],
+            'migrations_paths' => \array_merge(
+                $migrationsPath ?? [],
+                [
+                    'Sylius\InvoicingPlugin\Migrations' => '@SyliusInvoicingPlugin/Migrations',
+                ]
+            ),
         ]);
 
         $container->prependExtensionConfig('sylius_labs_doctrine_migrations_extra', [

--- a/tests/Application/config/packages/doctrine_migrations.yaml
+++ b/tests/Application/config/packages/doctrine_migrations.yaml
@@ -1,0 +1,6 @@
+doctrine_migrations:
+    storage:
+        table_storage:
+            table_name: sylius_migrations
+    migrations_paths:
+        'App\Migrations': '%kernel.project_dir%/src/Migrations/'


### PR DESCRIPTION
Fixes #192 

Without this change, migrations are generated into the plugin's directory rather than `src/Migrations`. I'm wondering do we need/want to have a test for the proper migrations directory like in [the PayPalPlugin](https://github.com/Sylius/PayPalPlugin/pull/163/commits/b1d268568ec523fe9b707830d11c6d2b58917c93)? 🤷‍♂️ 