### PR TITLE
Force invoice relations

### DIFF
--- a/src/Migrations/Version20201124102609.php
+++ b/src/Migrations/Version20201124102609.php
@@ -9,13 +9,13 @@ use Doctrine\Migrations\AbstractMigration;
 
 final class Version20201124102609 extends AbstractMigration
 {
-    public function up(Schema $schema) : void
+    public function up(Schema $schema): void
     {
         // this up() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_invoicing_plugin_invoice CHANGE billing_data_id billing_data_id INT NOT NULL, CHANGE shop_billing_data_id shop_billing_data_id INT NOT NULL, CHANGE channel_id channel_id INT NOT NULL');
     }
 
-    public function down(Schema $schema) : void
+    public function down(Schema $schema): void
     {
         // this down() migration is auto-generated, please modify it to your needs
         $this->addSql('ALTER TABLE sylius_invoicing_plugin_invoice CHANGE billing_data_id billing_data_id INT DEFAULT NULL, CHANGE shop_billing_data_id shop_billing_data_id INT DEFAULT NULL, CHANGE channel_id channel_id INT DEFAULT NULL');

--- a/src/Migrations/Version20201124102609.php
+++ b/src/Migrations/Version20201124102609.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\InvoicingPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20201124102609 extends AbstractMigration
+{
+    public function up(Schema $schema) : void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_invoicing_plugin_invoice CHANGE billing_data_id billing_data_id INT NOT NULL, CHANGE shop_billing_data_id shop_billing_data_id INT NOT NULL, CHANGE channel_id channel_id INT NOT NULL');
+    }
+
+    public function down(Schema $schema) : void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_invoicing_plugin_invoice CHANGE billing_data_id billing_data_id INT DEFAULT NULL, CHANGE shop_billing_data_id shop_billing_data_id INT DEFAULT NULL, CHANGE channel_id channel_id INT DEFAULT NULL');
+    }
+}

--- a/src/Resources/config/doctrine/Invoice.orm.xml
+++ b/src/Resources/config/doctrine/Invoice.orm.xml
@@ -15,7 +15,7 @@
             <cascade>
                 <cascade-all/>
             </cascade>
-            <join-column name="billing_data_id" />
+            <join-column name="billing_data_id" nullable="false" />
         </one-to-one>
 
         <one-to-many field="lineItems" target-entity="Sylius\InvoicingPlugin\Entity\LineItemInterface" mapped-by="invoice" orphan-removal="true">
@@ -31,14 +31,14 @@
         </one-to-many>
 
         <many-to-one field="channel" target-entity="Sylius\Component\Core\Model\ChannelInterface">
-            <join-column name="channel_id" />
+            <join-column name="channel_id" nullable="false" />
         </many-to-one>
 
         <one-to-one field="shopBillingData" target-entity="Sylius\InvoicingPlugin\Entity\InvoiceShopBillingDataInterface">
             <cascade>
                 <cascade-all />
             </cascade>
-            <join-column name="shop_billing_data_id" referenced-column-name="id" />
+            <join-column name="shop_billing_data_id" referenced-column-name="id" nullable="false" />
         </one-to-one>
 
         <indexes>


### PR DESCRIPTION
I found a potential issue happening if you have trouble enhancing the `Invoice` entity, the `billingData` and `shopBillingData` could become null because doctrine could lost the cascade all in some particular entity override cases.
This PR add nullable false to those relations to avoid getting null value in the database.

I also remove the `tests/Application/src/Migrations/Version*.php` because they are no longer required thanks to doctrine migration update.