### PR TITLE
Add translation in invoice PDF file

### DIFF
--- a/src/Resources/views/Invoice/Download/pdf.html.twig
+++ b/src/Resources/views/Invoice/Download/pdf.html.twig
@@ -31,8 +31,8 @@
                         </td>
 
                         <td>
-                            Invoice #{{ invoice.number }}<br>
-                            Issued at: {{ invoice.issuedAt|format_datetime }}<br>
+                            {{ 'sylius_invoicing_plugin.ui.invoice'|trans }} #{{ invoice.number }}<br>
+                            {{ 'sylius_invoicing_plugin.ui.issued_at'|trans }}: {{ invoice.issuedAt|format_datetime }}<br>
                         </td>
                     </tr>
                 </table>


### PR DESCRIPTION
`sylius_invoicing_plugin.ui.invoice` and `sylius_invoicing_plugin.ui.issued_at` are in `translations/messages`.