### PR TITLE
Update console command definition to SF 4.4 standards

### DIFF
--- a/src/Cli/GenerateInvoicesCommand.php
+++ b/src/Cli/GenerateInvoicesCommand.php
@@ -21,6 +21,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class GenerateInvoicesCommand extends Command
 {
+    protected static string $defaultName = 'sylius-invoicing:generate-invoices';
+
     private MassInvoicesCreatorInterface $massInvoicesCreator;
 
     private OrderRepositoryInterface $orderRepository;
@@ -29,10 +31,15 @@ final class GenerateInvoicesCommand extends Command
         MassInvoicesCreatorInterface $massInvoicesCreator,
         OrderRepositoryInterface $orderRepository
     ) {
-        parent::__construct('sylius-invoicing:generate-invoices');
-
         $this->massInvoicesCreator = $massInvoicesCreator;
         $this->orderRepository = $orderRepository;
+
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Generates invoices for orders placed before InvoicingPlugin installation');
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
@@ -49,10 +56,5 @@ final class GenerateInvoicesCommand extends Command
         $output->writeln('Invoices generated successfully');
 
         return 0;
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Generates invoices for orders placed before InvoicingPlugin installation');
     }
 }

--- a/src/Cli/GenerateInvoicesCommand.php
+++ b/src/Cli/GenerateInvoicesCommand.php
@@ -21,7 +21,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 final class GenerateInvoicesCommand extends Command
 {
-    protected static string $defaultName = 'sylius-invoicing:generate-invoices';
+    protected static $defaultName = 'sylius-invoicing:generate-invoices';
 
     private MassInvoicesCreatorInterface $massInvoicesCreator;
 
@@ -35,11 +35,6 @@ final class GenerateInvoicesCommand extends Command
         $this->orderRepository = $orderRepository;
 
         parent::__construct();
-    }
-
-    protected function configure(): void
-    {
-        $this->setDescription('Generates invoices for orders placed before InvoicingPlugin installation');
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int
@@ -56,5 +51,10 @@ final class GenerateInvoicesCommand extends Command
         $output->writeln('Invoices generated successfully');
 
         return 0;
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Generates invoices for orders placed before InvoicingPlugin installation');
     }
 }

--- a/src/Resources/config/services/cli.xml
+++ b/src/Resources/config/services/cli.xml
@@ -7,7 +7,7 @@
         <service id="sylius_invoicing_plugin.cli.generate_invoices" class="Sylius\InvoicingPlugin\Cli\GenerateInvoicesCommand">
             <argument type="service" id="sylius_invoicing_plugin.creator.mass_invoices" />
             <argument type="service" id="sylius.repository.order" />
-            <tag name="console.command" command="sylius-invoicing:generate-invoices" />
+            <tag name="console.command" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
Non-BC maintenance change.

1. While command was already lazy loaded via DI definition, I think it's a better practice to keep command name in class itself + removal of misuse of constructor call.
https://symfony.com/doc/current/console/commands_as_services.html#lazy-loading
2. It's good practice to define `parent::__construct()` last. No practical difference for the current setup though.
![image](https://user-images.githubusercontent.com/870747/108474231-abb5b900-72c1-11eb-928b-d12652b99b99.png)
https://symfony.com/doc/4.4/console.html#configuring-the-command

On separate note, will you accept progress bar for this command? It will require to do something with Generators like that
```php
// src/Cli/GenerateInvoicesCommand.php
$this->massInvoicesCreator->setGenerateResult(true);

foreach ($this->massInvoicesCreator->__invoke($orders) as $result) {
    $progressBar->advance();
}

// src/Creator/MassInvoicesCreator.php
     {   
         /** @var OrderInterface $order */
         foreach ($orders as $order) {
             try {
                 $this->invoiceCreator->__invoke($order->getNumber(), $this->dateTimeProvider->__invoke());
                 if (true === $this->generateResult) {
                     yield true;
                 }
             } catch (InvoiceAlreadyGenerated $exception) {
                 continue;
             }
         }
     }   
```
or let me know if there is standard practice on how to expose progress to console from other services.