### PR TITLE
Minor admin ui redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ both customer and admin to download invoices related to the order.
 
 ## Business value
 
-The primary aim of Invoicing Plugin is to create a document representing Customer's will to buy particular products and 
+The primary aim of Invoicing Plugin is to create a document representing Customer's will to buy particular products and
 pay for them.
 
-An Invoice can also be treated as a proof of placing an Order. Thus, it is downloadable as .pdf file and can be sent to 
+An Invoice can also be treated as a proof of placing an Order. Thus, it is downloadable as .pdf file and can be sent to
 Customer manually by the Administrator or automatically once an Order is paid.
 
 Additional feature of the plugin that fulfills Invoicing domain is the ability to set billing data on a Seller.
@@ -33,17 +33,17 @@ Additional feature of the plugin that fulfills Invoicing domain is the ability t
     ```bash
     composer require sylius/invoicing-plugin
     ```
-    
+
     > Remember to allow community recipes with `composer config extra.symfony.allow-contrib true` or during plugin installation process
 
-1. Apply migrations to your database:
+2. Apply migrations to your database:
 
     ```bash
     bin/console doctrine:migrations:migrate
     ```
 
-1. Check if you have wkhtmltopdf binary. If not, you can download it [here](https://wkhtmltopdf.org/downloads.html).
-   
+3. Check if you have wkhtmltopdf binary. If not, you can download it [here](https://wkhtmltopdf.org/downloads.html).
+
 In case wkhtmltopdf is not located in `/usr/local/bin/wkhtmltopdf` modify the `WKHTMLTOPDF_PATH` environment variable in the `.env` file:
 
 ```
@@ -114,19 +114,14 @@ Sonata events. You can read about customizing templates via events here:
 
 <http://docs.sylius.com/en/latest/customization/template.html>
 
-Invoicing Plugin renders invoices grid using a certain pattern, including displaying a dot next to channel in which an invoice as issued.
-The dot's color is dependant on a property defined on Channel entity or, if not provided, a global parameter named `default_channel_color`.
-
-Like any other parameter, `default_channel_color` can also be overwritten in your `config.yml` file.
-
 ### Invoices files
 
 By default, when the order is paid, an immutable Invoice pdf file is saved on the server. The save directory is specified
-with `%sylius_invoicing.invoice_save_path%` parameter, that can be overridden if needed. 
+with `%sylius_invoicing.invoice_save_path%` parameter, that can be overridden if needed.
 
 There is no direct relation between `Sylius\InvoicingPlugin\Entity\Invoice` entity and its file. It's resolved based on
 the `Invoice::$number`, which is defined in `Sylius\InvoicingPlugin\Provider\InvoiceFileProviderInterface` service.
-By overriding this service, you can change a logic that is used to retrieve the invoice file.  
+By overriding this service, you can change a logic that is used to retrieve the invoice file.
 
 ## Fixtures
 
@@ -135,5 +130,5 @@ More instructions on the [fixtures configuration instructions](docs/fixtures.md)
 
 ## Security issues
 
-If you think that you have found a security issue, please do not use the issue tracker and do not post it publicly. 
+If you think that you have found a security issue, please do not use the issue tracker and do not post it publicly.
 Instead, all security issues must be sent to `security@sylius.com`.

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ Additional feature of the plugin that fulfills Invoicing domain is the ability t
 
 3. Check if you have wkhtmltopdf binary. If not, you can download it [here](https://wkhtmltopdf.org/downloads.html).
 
-In case wkhtmltopdf is not located in `/usr/local/bin/wkhtmltopdf` modify the `WKHTMLTOPDF_PATH` environment variable in the `.env` file:
+    In case wkhtmltopdf is not located in `/usr/local/bin/wkhtmltopdf` modify the `WKHTMLTOPDF_PATH` environment variable in the `.env` file:
 
-```
-WKHTMLTOPDF_PATH=/usr/local/bin/wkhtmltopdf # Change this! :)
-```
+    ```
+    WKHTMLTOPDF_PATH=/usr/local/bin/wkhtmltopdf # Change this! :)
+    ```
 
-1. If you want to generate invoices for orders placed before plugin's installation run the following command using your terminal:
+4. If you want to generate invoices for orders placed before plugin's installation run the following command using your terminal:
 
    ```bash
    bin/console sylius-invoicing:generate-invoices

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,16 +1,22 @@
 ### UPGRADE FROM 0.18.0 TO 0.19.0
 
 1. Support for Sylius 1.9 has been dropped, upgrade your application to [Sylius 1.10](https://github.com/Sylius/Sylius/blob/master/UPGRADE-1.10.md).
-1. Support for Symfony 5.2 has been dropped.
+2. Support for Symfony 5.2 has been dropped.
+3. Default channel color feature was removed in favour of `sylius/sylius` standard solution.
+Override `src/Sylius/Bundle/AdminBundle/Resources/views/Common/_channel.html.twig` if custom default color is neccesasary.
+    - Class `Sylius\InvoicingPlugin\Provider\ChannelColorProvider` was removed.
+    - Interface `Sylius\InvoicingPlugin\Provider\ChannelColorProviderInterface` was removed.
+    - Class `Sylius\InvoicingPlugin\Twig\ChannelColorExtension` and twig filter `sylius_channel_color` were removed.
+    - Parameter `default_channel_color` was removed
 
 ### UPGRADE FROM 0.17.0 TO 0.18.0
 
 1. The `Sylius\InvoicingPlugin\Converter\BillingDataConverter` has been removed in favor of `Sylius\InvoicingPlugin\Factory\BillingDataFactory->createFromAddress`.
-1. The `Sylius\InvoicingPlugin\Converter\InvoiceShopBillingDataConverter` has been removed in favor of `Sylius\InvoicingPlugin\Factory\InvoiceShopBillingDataFactory->createFromChannel`.
+2. The `Sylius\InvoicingPlugin\Converter\InvoiceShopBillingDataConverter` has been removed in favor of `Sylius\InvoicingPlugin\Factory\InvoiceShopBillingDataFactory->createFromChannel`.
 
 Now on invoice admin and shop user can check if related order was paid before invoice generated.
 
-1. `src/Entity/Invoice.php` model has new field (`paymentState`), and updated constructor arguments: 
+1. `src/Entity/Invoice.php` model has new field (`paymentState`), and updated constructor arguments:
 
     ```dif
         public function __construct(
@@ -40,12 +46,12 @@ Now on invoice admin and shop user can check if related order was paid before in
             $this->taxItems = $taxItems;
             $this->channel = $channel;
     +       $this->paymentState = $paymentState;
-            $this->shopBillingData = $shopBillingData; 
+            $this->shopBillingData = $shopBillingData;
    ```
-   
-1. New field on `src/Entity/Invoice.php` implies a database update
-   
-1. Method `createForData` from `src/Factory/InvoiceFactory.php` service was updated: 
+
+2. New field on `src/Entity/Invoice.php` implies a database update
+
+3. Method `createForData` from `src/Factory/InvoiceFactory.php` service was updated:
 
     ```dif
         public function createForData(
@@ -73,59 +79,58 @@ Invoices are now saved on the server during their generation (by default, when t
 
 1. `Sylius\InvoicingPlugin\Creator\InvoiceCreator` class has 2 more dependencies: `InvoicePdfFileGeneratorInterface $invoicePdfFileGenerator`
     and `InvoiceFileManagerInterface $invoiceFileManager`
-1. `Sylius\InvoicingPlugin\Email\InvoiceEmailSender` class 2nd dependency has been changed from `InvoicePdfFileGeneratorInterface $invoicePdfFileGenerator`
+2. `Sylius\InvoicingPlugin\Email\InvoiceEmailSender` class 2nd dependency has been changed from `InvoicePdfFileGeneratorInterface $invoicePdfFileGenerator`
     to `InvoiceFileProviderInterface $invoiceFileProvider`
-1. `Sylius\InvoicingPlugin\Generator\InvoicePdfFileGenerator` class has additional `InvoiceFileNameGeneratorInterface $invoiceFileNameGenerator`
+3. `Sylius\InvoicingPlugin\Generator\InvoicePdfFileGenerator` class has additional `InvoiceFileNameGeneratorInterface $invoiceFileNameGenerator`
     dependency, placed on 4th place, before `string $template`
-1. `Sylius\InvoicingPlugin\Ui\Action\DownloadInvoiceAction` class 4th dependency has been changed from `InvoicePdfFileGeneratorInterface $invoicePdfFileGenerator`
+4. `Sylius\InvoicingPlugin\Ui\Action\DownloadInvoiceAction` class 4th dependency has been changed from `InvoicePdfFileGeneratorInterface $invoicePdfFileGenerator`
     to `InvoiceFileProviderInterface $invoiceFilePathProvider`
-1. `Sylius\InvoicingPlugin\Converter\LineItemsConverter` class has additional `TaxRatePercentageProviderInterface $taxRatePercentageProvider`
+5. `Sylius\InvoicingPlugin\Converter\LineItemsConverter` class has additional `TaxRatePercentageProviderInterface $taxRatePercentageProvider`
    dependency
-1. `Sylius\InvoicingPlugin\Provider\TaxRateProvider` service has been changed to `Sylius\InvoicingPlugin\Provider\TaxRatePercentageProvider`
+6. `Sylius\InvoicingPlugin\Provider\TaxRateProvider` service has been changed to `Sylius\InvoicingPlugin\Provider\TaxRatePercentageProvider`
    and its service definition from `sylius_invoicing_plugin.provider.tax_rate` to `sylius_invoicing_plugin.provider.tax_rate_percentage`
-1. `Sylius\InvoicingPlugin\Converter\LineItemsConverter` service has been replaced by `Sylius\InvoicingPlugin\Converter\OrderItemUnitsToLineItemsConverter`
+7. `Sylius\InvoicingPlugin\Converter\LineItemsConverter` service has been replaced by `Sylius\InvoicingPlugin\Converter\OrderItemUnitsToLineItemsConverter`
    and `Sylius\InvoicingPlugin\Converter\ShippingAdjustmentsToLineItemsConverter`
-1. `Sylius\InvoicingPlugin\Generator\InvoiceGenerator` class has 2 more dependencies: `LineItemsConverterInterface $orderItemUnitsToLineItemsConverter`
+8. `Sylius\InvoicingPlugin\Generator\InvoiceGenerator` class has 2 more dependencies: `LineItemsConverterInterface $orderItemUnitsToLineItemsConverter`
    and `LineItemsConverterInterface $shippingAdjustmentsToLineItemsConverter` that replaced `LineItemsConverterInterface $lineItemsConverter`
-1. The return type of `Sylius\InvoicingPlugin\Converter\LineItemsConverterInterface:convert` method has been changed 
+9. The return type of `Sylius\InvoicingPlugin\Converter\LineItemsConverterInterface:convert` method has been changed
    from `Collection` to `array`
-1. `Sylius\InvoicingPlugin\Filesystem\TemporaryFilesystem` class has been removed
+10. `Sylius\InvoicingPlugin\Filesystem\TemporaryFilesystem` class has been removed
 
 ### UPGRADE FROM 0.15.0 TO 0.16.0
 
 1. `orderNumber` field on `Sylius\InvoicingPlugin\Entity\Invoice` has been removed and replaced with relation to `Order` entity.
-1. `Sylius\InvoicingPlugin\Entity\InvoiceInterface::orderNumber` function is left due to easier and smoother upgrades,
+2. `Sylius\InvoicingPlugin\Entity\InvoiceInterface::orderNumber` function is left due to easier and smoother upgrades,
    but is also deprecated and will be removed in the `v1.0.0` release. Use `Sylius\InvoicingPlugin\Entity\InvoiceInterface::order` instead.
-1. `Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepositoryInterface::findOneByOrderNumber` method has been replaced by
+3. `Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepositoryInterface::findOneByOrderNumber` method has been replaced by
    `Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepositoryInterface::findOneByOrder`.
-1. `Sylius\InvoicingPlugin\Factory\InvoiceFactoryInterface::createForData` takes `OrderInterface $order` as the 3rd argument instead
+4. `Sylius\InvoicingPlugin\Factory\InvoiceFactoryInterface::createForData` takes `OrderInterface $order` as the 3rd argument instead
     of `string $orderNumber`.
 
 ### UPGRADE FROM 0.14.0 TO 0.15.0
 
 1. Command bus `sylius_invoicing_plugin.command_bus` has been replaced with `sylius.command_bus`.
 
-1. Event bus `sylius_invoicing_plugin.event_bus` has been replaced with `sylius.event_bus`.
+2. Event bus `sylius_invoicing_plugin.event_bus` has been replaced with `sylius.event_bus`.
 
-1. Support for Sylius 1.8 has been dropped, upgrade your application to [Sylius 1.9](https://github.com/Sylius/Sylius/blob/master/UPGRADE-1.9.md) 
+3. Support for Sylius 1.8 has been dropped, upgrade your application to [Sylius 1.9](https://github.com/Sylius/Sylius/blob/master/UPGRADE-1.9.md)
 or [Sylius 1.10](https://github.com/Sylius/Sylius/blob/master/UPGRADE-1.10.md).
 
 ### UPGRADE FROM 0.11.0 TO 0.12.0
 
 1. The custom repository has been removed:
-
-  - the repository class `Sylius\InvoicingPlugin\Repository\DoctrineInvoiceRepository` has been removed 
-  and replaced by `Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepository`.
-  - the related service `sylius_invoicing_plugin.custom_repository.invoice` has been removed,
-   use `sylius_invoicing_plugin.repository.invoice` instead
-  - the related interface `Sylius\InvoicingPlugin\Repository\InvoiceRepository` has been removed, 
-  use `Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepositoryInterface` instead.
+    - the repository class `Sylius\InvoicingPlugin\Repository\DoctrineInvoiceRepository` has been removed
+    and replaced by `Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepository`.
+    - the related service `sylius_invoicing_plugin.custom_repository.invoice` has been removed,
+     use `sylius_invoicing_plugin.repository.invoice` instead
+    - the related interface `Sylius\InvoicingPlugin\Repository\InvoiceRepository` has been removed,
+    use `Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepositoryInterface` instead.
 
 ### UPGRADE FROM 0.10.X TO 0.11.0
 
 1. Upgrade your application to [Sylius 1.8](https://github.com/Sylius/Sylius/blob/master/UPGRADE-1.8.md).
 
-1. Remove previously copied migration files (You may check migrations to remove [here](https://github.com/Sylius/InvoicingPlugin/pull/184)).
+2. Remove previously copied migration files (You may check migrations to remove [here](https://github.com/Sylius/InvoicingPlugin/pull/184)).
 
 ### UPGRADE FROM 0.9 TO 0.10.0
 

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -1,5 +1,4 @@
 parameters:
-    default_channel_color: "lightGrey"
     sylius_invoicing.invoice_save_path: "%kernel.project_dir%/private/invoices/"
     sylius_invoicing.filesystem_adapter.invoice: "sylius_invoicing_invoice"
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -32,11 +32,6 @@
             <tag name="security.voter" />
         </service>
 
-        <service id="sylius_invoicing_plugin.provider.channel_color" class="Sylius\InvoicingPlugin\Provider\ChannelColorProvider">
-            <argument type="service" id="sylius.repository.channel" />
-            <argument>%default_channel_color%</argument>
-        </service>
-
         <service id="sylius_invoicing_plugin.provider.tax_rate_percentage" class="Sylius\InvoicingPlugin\Provider\TaxRatePercentageProvider" />
 
         <service id="sylius_invoicing_plugin.custom_factory.invoice" class="Sylius\InvoicingPlugin\Factory\InvoiceFactory">

--- a/src/Resources/config/services/ui.xml
+++ b/src/Resources/config/services/ui.xml
@@ -17,11 +17,6 @@
             <tag name="sylius.grid_filter" type="invoice_channel" form_type="Sylius\InvoicingPlugin\Form\Type\ChannelFilterType" />
         </service>
 
-        <service id="sylius_invoicing_plugin.twig.channel_color_extension" class="Sylius\InvoicingPlugin\Twig\ChannelColorExtension">
-            <argument type="service" id="sylius_invoicing_plugin.provider.channel_color" />
-            <tag name="twig.extension" />
-        </service>
-
         <service id="Sylius\InvoicingPlugin\Ui\RedirectToOrderShowAction">
             <argument type="service" id="router" />
             <argument type="service" id="sylius.repository.order" />

--- a/src/Resources/views/Invoice/Grid/Field/channel.html.twig
+++ b/src/Resources/views/Invoice/Grid/Field/channel.html.twig
@@ -1,1 +1,1 @@
-<span class="ui small horizontal circular label" style="background-color: {{ data.code|sylius_channel_color }}"></span> {{ data.name }}
+{% include '@SyliusAdmin/Common/_channel.html.twig' with {'channel': data} %}

--- a/src/Resources/views/Invoice/Show/_header.html.twig
+++ b/src/Resources/views/Invoice/Show/_header.html.twig
@@ -12,7 +12,7 @@
                 </div>
                 <div class="item">
                     {{ 'sylius_invoicing_plugin.ui.issued_from'|trans }}
-                    <span class="ui large empty horizontal circular label"></span> <strong id="invoice-channel-name">{{ invoice.channel.name }}</strong>
+                    {% include '@SyliusAdmin/Common/_channel.html.twig' with {'channel': invoice.channel} %}
                 </div>
             </div>
         </div>

--- a/src/Resources/views/Invoice/show.html.twig
+++ b/src/Resources/views/Invoice/show.html.twig
@@ -17,7 +17,7 @@
             {{ buttons.default(path, '', 'back', 'arrow alternate circle left outline') }}
 
             {% set path = path('sylius_invoicing_plugin_admin_invoice_download', {'id': invoice.id}) %}
-            {{ buttons.default(path, 'sylius_invoicing_plugin.ui.download_invoice'|trans, invoice.id, 'download') }}
+            {{ buttons.default(path, 'sylius_invoicing_plugin.ui.download_invoice'|trans, invoice.id, 'download', 'blue') }}
 
             {% set path = path('sylius_invoicing_plugin_admin_invoice_resend', {'id': invoice.id}) %}
             {{ buttons.default(path, 'sylius_invoicing_plugin.ui.resend_invoice'|trans, invoice.id, 'send') }}

--- a/src/Resources/views/Order/Admin/_invoices.html.twig
+++ b/src/Resources/views/Order/Admin/_invoices.html.twig
@@ -23,13 +23,13 @@
                     {{ invoice.issuedAt|format_date }}
                 </td>
                 <td>
-                    {% set path = path('sylius_invoicing_plugin_admin_invoice_download', { 'id': invoice.id }) %}
+                    <div class="ui buttons">
+                        {% set path = path('sylius_invoicing_plugin_admin_invoice_download', { 'id': invoice.id }) %}
+                        {{ buttons.default(path, 'sylius_invoicing_plugin.ui.download_invoice'|trans, invoice.id, 'download', 'blue') }}
 
-                    {{ buttons.default(path, 'sylius_invoicing_plugin.ui.download_invoice'|trans, invoice.id, 'download') }}
-
-                    {% set path = path('sylius_invoicing_plugin_admin_invoice_resend', { 'id': invoice.id }) %}
-
-                    {{ buttons.default(path, 'sylius_invoicing_plugin.ui.resend_invoice'|trans, invoice.id, 'send') }}
+                        {% set path = path('sylius_invoicing_plugin_admin_invoice_resend', { 'id': invoice.id }) %}
+                        {{ buttons.default(path, 'sylius_invoicing_plugin.ui.resend_invoice'|trans, invoice.id, 'send') }}
+                    </div>
                 </td>
             </tr>
         {% endfor %}

--- a/src/Resources/views/Order/Admin/_invoices.html.twig
+++ b/src/Resources/views/Order/Admin/_invoices.html.twig
@@ -17,7 +17,8 @@
                 <td>
                     <a href="{{ path('sylius_invoicing_plugin_admin_invoice_show', {'id': invoice.id}) }}" >{{ invoice.number }}</a>
                 </td>
-                <td>{{ invoice.channel.name }}</td>
+                <td>
+                    {% include '@SyliusAdmin/Common/_channel.html.twig' with {'channel': invoice.channel} %}
                 <td>
                     {{ invoice.issuedAt|format_date }}
                 </td>

--- a/tests/Behat/Page/Admin/Invoice/ShowPage.php
+++ b/tests/Behat/Page/Admin/Invoice/ShowPage.php
@@ -168,7 +168,6 @@ final class ShowPage extends SymfonyPage implements ShowPageInterface
         return array_merge(parent::getDefinedElements(), [
             'back' => '#back',
             'billing_address' => '#billing-data',
-            'invoice_channel_name' => '#invoice-channel-name',
             'invoice_net_total' => '[data-test-invoice-net-total]',
             'invoice_net_total_currency_code' => '[data-test-invoice-net-total-currency-code]',
             'invoice_taxes_total' => '[data-test-invoice-taxes-total]',

--- a/tests/Behat/Page/Admin/Invoice/ShowPage.php
+++ b/tests/Behat/Page/Admin/Invoice/ShowPage.php
@@ -138,7 +138,9 @@ final class ShowPage extends SymfonyPage implements ShowPageInterface
 
     public function getChannel(): string
     {
-        return $this->getElement('invoice_channel_name')->getText();
+        $items = $this->getDocument()->findAll('css', '.channel > .channel__item');
+
+        return $items[1]->getText();
     }
 
     public function download(): void


### PR DESCRIPTION
1.  Replace channel color feature with sylius/sylius standard template
    * Header of invoice show page
Before
![image](https://user-images.githubusercontent.com/870747/108959322-d67b8500-76a6-11eb-819e-6b3f998750ac.png)
After
![image](https://user-images.githubusercontent.com/870747/108959403-ee530900-76a6-11eb-9761-167fac6e287f.png)
    * Channel column for invoices index page
Before
![image](https://user-images.githubusercontent.com/870747/108959091-80a6dd00-76a6-11eb-9ccb-0c462a29f410.png)
After
![image](https://user-images.githubusercontent.com/870747/108958977-535a2f00-76a6-11eb-9b24-4658897a3e52.png)
    * Order show page, list of invoices
Before
![image](https://user-images.githubusercontent.com/870747/108963650-f8780600-76ac-11eb-8ea1-b17eb1808212.png)
After
![image](https://user-images.githubusercontent.com/870747/108963699-07f74f00-76ad-11eb-9323-5288b45c573c.png)
2. Move breadcrumb block at invoices admin show page to correct place as for other CRUD templates
Before
![image](https://user-images.githubusercontent.com/870747/108960290-42122200-76a8-11eb-8123-18d7aaed817a.png)
After
![image](https://user-images.githubusercontent.com/870747/108960316-4c342080-76a8-11eb-9a08-5adb49c934e8.png)
3. Move seller/buyer blocks on top of the page, same as for CreditMemo show page
Before
![image](https://user-images.githubusercontent.com/870747/108967402-0ed49080-76b2-11eb-91c8-1d7d3247687a.png)
After
![image](https://user-images.githubusercontent.com/870747/108967565-43484c80-76b2-11eb-9297-ab7e848e99ae.png)
4. Wrap action buttons with button group for order's invoices list (Download btn colored blue as secondary action blue in the same schema as for credit memo download btn. "Resend" btn left grey the same as for "resend order confirmation"/"resend shipment confirmation" btns)
Before
![image](https://user-images.githubusercontent.com/870747/108968984-0da46300-76b4-11eb-9a4e-6a6bfd785f63.png)
After
![image](https://user-images.githubusercontent.com/870747/108968832-dd5cc480-76b3-11eb-8649-4c76237cf01d.png)
And credit memos for context (Do ignore slightly non-standard view, artifact of the project)
![image](https://user-images.githubusercontent.com/870747/108969805-6247de00-76b4-11eb-8373-00eb96f6ae0b.png)
5.
Before
![image](https://user-images.githubusercontent.com/870747/108973398-dedbbc00-76b6-11eb-905b-2143e6a9217a.png)
After
![image](https://user-images.githubusercontent.com/870747/108973317-c79cce80-76b6-11eb-943b-fc46d426f21c.png)

Let me know if you would like to change something.

@lchrusciel @GSadee @CoderMaggie review please :)