### PR TITLE
change information on WKHTMLTOPDF_PATH in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,10 @@ Additional feature of the plugin that fulfills Invoicing domain is the ability t
 
 3. Check if you have wkhtmltopdf binary. If not, you can download it [here](https://wkhtmltopdf.org/downloads.html).
    
-In case wkhtmltopdf is not located in /usr/local/bin/wkhtmltopdf, add a following snippet at the end of your application's config.yml:
+In case wkhtmltopdf is not located in /usr/local/bin/wkhtmltopdf modify the `WKHTMLTOPDF_PATH` environment variable in the `.env` file:
 
 ```
-knp_snappy:
-    pdf:
-        enabled: true
-        binary: /usr/local/bin/wkhtmltopdf # Change this! :)
-        options: []
+WKHTMLTOPDF_PATH=/usr/local/bin/wkhtmltopdf # Change this! :)
 ```
 
 4. If you want to generate invoices for orders placed before plugin's installation run the following command using your terminal:


### PR DESCRIPTION
The configuration for the WKHTMLTOPDF_PATH is in the .env file, the yaml configuration file uses the environment variable.