### PR TITLE
Do not require visibility in PHPSpec functions

### DIFF
--- a/spec/Command/SendInvoiceEmailSpec.php
+++ b/spec/Command/SendInvoiceEmailSpec.php
@@ -17,7 +17,7 @@ use PhpSpec\ObjectBehavior;
 
 final class SendInvoiceEmailSpec extends ObjectBehavior
 {
-    public function it_represents_an_intention_to_send_email_containing_invoice(): void
+    function it_represents_an_intention_to_send_email_containing_invoice(): void
     {
         $this->beConstructedWith('0000001');
 

--- a/spec/CommandHandler/SendInvoiceEmailHandlerSpec.php
+++ b/spec/CommandHandler/SendInvoiceEmailHandlerSpec.php
@@ -24,7 +24,7 @@ use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
 
 final class SendInvoiceEmailHandlerSpec extends ObjectBehavior
 {
-    public function let(
+    function let(
         InvoiceRepositoryInterface $invoiceRepository,
         OrderRepositoryInterface $orderRepository,
         InvoiceEmailSenderInterface $emailSender
@@ -32,7 +32,7 @@ final class SendInvoiceEmailHandlerSpec extends ObjectBehavior
         $this->beConstructedWith($invoiceRepository, $orderRepository, $emailSender);
     }
 
-    public function it_requests_an_email_with_an_invoice_to_be_sent(
+    function it_requests_an_email_with_an_invoice_to_be_sent(
         InvoiceRepositoryInterface $invoiceRepository,
         OrderRepositoryInterface $orderRepository,
         InvoiceEmailSenderInterface $emailSender,
@@ -53,7 +53,7 @@ final class SendInvoiceEmailHandlerSpec extends ObjectBehavior
         $this->__invoke(new SendInvoiceEmail('0000001', new \DateTime('now')));
     }
 
-    public function it_does_not_request_an_email_to_be_sent_if_invoice_was_not_found(
+    function it_does_not_request_an_email_to_be_sent_if_invoice_was_not_found(
         InvoiceRepositoryInterface $invoiceRepository,
         OrderRepositoryInterface $orderRepository,
         InvoiceEmailSenderInterface $emailSender,

--- a/spec/Converter/BillingDataConverterSpec.php
+++ b/spec/Converter/BillingDataConverterSpec.php
@@ -20,12 +20,12 @@ use Sylius\InvoicingPlugin\Entity\BillingDataInterface;
 
 final class BillingDataConverterSpec extends ObjectBehavior
 {
-    public function it_implements_billing_data_converter_interface(): void
+    function it_implements_billing_data_converter_interface(): void
     {
         $this->shouldImplement(BillingDataConverterInterface::class);
     }
 
-    public function it_converts_address_to_billing_data(AddressInterface $address): void
+    function it_converts_address_to_billing_data(AddressInterface $address): void
     {
         $address->getCountryCode()->willReturn('US');
         $address->getCity()->willReturn('Las Vegas');

--- a/spec/Converter/InvoiceShopBillingDataConverterSpec.php
+++ b/spec/Converter/InvoiceShopBillingDataConverterSpec.php
@@ -21,12 +21,12 @@ use Sylius\InvoicingPlugin\Entity\InvoiceShopBillingDataInterface;
 
 final class InvoiceShopBillingDataConverterSpec extends ObjectBehavior
 {
-    public function it_implements_invoice_shop_billing_data_converter_interface(): void
+    function it_implements_invoice_shop_billing_data_converter_interface(): void
     {
         $this->shouldImplement(InvoiceShopBillingDataConverterInterface::class);
     }
 
-    public function it_extracts_shop_billing_data_from_channel(
+    function it_extracts_shop_billing_data_from_channel(
         ChannelInterface $channel,
         ShopBillingDataInterface $shopBillingData
     ): void {

--- a/spec/Converter/LineItemsConverterSpec.php
+++ b/spec/Converter/LineItemsConverterSpec.php
@@ -24,12 +24,12 @@ use Sylius\InvoicingPlugin\Converter\LineItemsConverterInterface;
 
 final class LineItemsConverterSpec extends ObjectBehavior
 {
-    public function it_implements_line_items_converter_interface(): void
+    function it_implements_line_items_converter_interface(): void
     {
         $this->shouldImplement(LineItemsConverterInterface::class);
     }
 
-    public function it_extracts_line_items_from_order(
+    function it_extracts_line_items_from_order(
         OrderInterface $order,
         OrderItemInterface $orderItem,
         AdjustmentInterface $shippingAdjustment,

--- a/spec/Converter/TaxItemsConverterSpec.php
+++ b/spec/Converter/TaxItemsConverterSpec.php
@@ -22,12 +22,12 @@ use Sylius\InvoicingPlugin\Converter\TaxItemsConverterInterface;
 
 final class TaxItemsConverterSpec extends ObjectBehavior
 {
-    public function it_implements_tax_items_converter_interface(): void
+    function it_implements_tax_items_converter_interface(): void
     {
         $this->shouldImplement(TaxItemsConverterInterface::class);
     }
 
-    public function it_extracts_tax_items_from_order(
+    function it_extracts_tax_items_from_order(
         OrderInterface $order,
         AdjustmentInterface $taxAdjustment
     ): void {

--- a/spec/Creator/InvoiceCreatorSpec.php
+++ b/spec/Creator/InvoiceCreatorSpec.php
@@ -29,7 +29,7 @@ use Sylius\InvoicingPlugin\Model\InvoicePdf;
 
 final class InvoiceCreatorSpec extends ObjectBehavior
 {
-    public function let(
+    function let(
         InvoiceRepositoryInterface $invoiceRepository,
         OrderRepositoryInterface $orderRepository,
         InvoiceGeneratorInterface $invoiceGenerator,
@@ -45,12 +45,12 @@ final class InvoiceCreatorSpec extends ObjectBehavior
         );
     }
 
-    public function it_implements_invoice_for_order_creator_interface(): void
+    function it_implements_invoice_for_order_creator_interface(): void
     {
         $this->shouldImplement(InvoiceCreatorInterface::class);
     }
 
-    public function it_creates_invoice_for_order(
+    function it_creates_invoice_for_order(
         InvoiceRepositoryInterface $invoiceRepository,
         OrderRepositoryInterface $orderRepository,
         InvoiceGeneratorInterface $invoiceGenerator,
@@ -76,7 +76,7 @@ final class InvoiceCreatorSpec extends ObjectBehavior
         $this->__invoke('0000001', $invoiceDateTime);
     }
 
-    public function it_removes_saved_invoice_file_if_database_update_fails(
+    function it_removes_saved_invoice_file_if_database_update_fails(
         InvoiceRepositoryInterface $invoiceRepository,
         OrderRepositoryInterface $orderRepository,
         InvoiceGeneratorInterface $invoiceGenerator,
@@ -103,7 +103,7 @@ final class InvoiceCreatorSpec extends ObjectBehavior
         $this->__invoke('0000001', $invoiceDateTime);
     }
 
-    public function it_throws_an_exception_when_invoice_was_already_created_for_given_order(
+    function it_throws_an_exception_when_invoice_was_already_created_for_given_order(
         InvoiceRepositoryInterface $invoiceRepository,
         OrderRepositoryInterface $orderRepository,
         InvoiceGeneratorInterface $invoiceGenerator,

--- a/spec/Creator/MassInvoicesCreatorSpec.php
+++ b/spec/Creator/MassInvoicesCreatorSpec.php
@@ -20,14 +20,14 @@ use Sylius\InvoicingPlugin\DateTimeProvider;
 
 final class MassInvoicesCreatorSpec extends ObjectBehavior
 {
-    public function let(
+    function let(
         InvoiceCreatorInterface $invoiceCreator,
         DateTimeProvider $dateTimeProvider
     ): void {
         $this->beConstructedWith($invoiceCreator, $dateTimeProvider);
     }
 
-    public function it_requests_invoices_creation_for_multiple_orders(
+    function it_requests_invoices_creation_for_multiple_orders(
         InvoiceCreatorInterface $invoiceCreator,
         DateTimeProvider $dateTimeProvider,
         OrderInterface $firstOrder,

--- a/spec/Entity/BillingDataSpec.php
+++ b/spec/Entity/BillingDataSpec.php
@@ -19,7 +19,7 @@ use Sylius\InvoicingPlugin\Entity\BillingDataInterface;
 
 final class BillingDataSpec extends ObjectBehavior
 {
-    public function let(): void
+    function let(): void
     {
         $this->beConstructedWith(
             'John',
@@ -34,17 +34,17 @@ final class BillingDataSpec extends ObjectBehavior
         );
     }
 
-    public function it_implements_billing_data_interface(): void
+    function it_implements_billing_data_interface(): void
     {
         $this->shouldImplement(BillingDataInterface::class);
     }
 
-    public function it_implements_resource_interface(): void
+    function it_implements_resource_interface(): void
     {
         $this->shouldImplement(ResourceInterface::class);
     }
 
-    public function it_has_proper_billing_data(): void
+    function it_has_proper_billing_data(): void
     {
         $this->firstName()->shouldReturn('John');
         $this->lastName()->shouldReturn('Doe');

--- a/spec/Entity/InvoiceSpec.php
+++ b/spec/Entity/InvoiceSpec.php
@@ -26,7 +26,7 @@ use Sylius\InvoicingPlugin\Entity\TaxItemInterface;
 
 final class InvoiceSpec extends ObjectBehavior
 {
-    public function let(
+    function let(
         BillingDataInterface $billingData,
         LineItemInterface $lineItem,
         TaxItemInterface $taxItem,
@@ -52,17 +52,17 @@ final class InvoiceSpec extends ObjectBehavior
         );
     }
 
-    public function it_implements_invoice_interface(): void
+    function it_implements_invoice_interface(): void
     {
         $this->shouldImplement(InvoiceInterface::class);
     }
 
-    public function it_implements_resource_interface(): void
+    function it_implements_resource_interface(): void
     {
         $this->shouldImplement(ResourceInterface::class);
     }
 
-    public function it_has_data(
+    function it_has_data(
         BillingDataInterface $billingData,
         LineItemInterface $lineItem,
         TaxItemInterface $taxItem,

--- a/spec/Entity/LineItemSpec.php
+++ b/spec/Entity/LineItemSpec.php
@@ -20,7 +20,7 @@ use Sylius\InvoicingPlugin\Entity\LineItemInterface;
 
 final class LineItemSpec extends ObjectBehavior
 {
-    public function let(): void
+    function let(): void
     {
         $this->beConstructedWith(
             'Mjolnir',
@@ -34,17 +34,17 @@ final class LineItemSpec extends ObjectBehavior
         );
     }
 
-    public function it_implements_line_item_interface(): void
+    function it_implements_line_item_interface(): void
     {
         $this->shouldImplement(LineItemInterface::class);
     }
 
-    public function it_implements_resource_interface(): void
+    function it_implements_resource_interface(): void
     {
         $this->shouldImplement(ResourceInterface::class);
     }
 
-    public function it_has_proper_line_item_data(): void
+    function it_has_proper_line_item_data(): void
     {
         $this->name()->shouldReturn('Mjolnir');
         $this->quantity()->shouldReturn(2);
@@ -56,7 +56,7 @@ final class LineItemSpec extends ObjectBehavior
         $this->variantCode()->shouldReturn('7903c83a-4c5e-4bcf-81d8-9dc304c6a353');
     }
 
-    public function it_has_an_invoice(InvoiceInterface $invoice): void
+    function it_has_an_invoice(InvoiceInterface $invoice): void
     {
         $this->setInvoice($invoice);
         $this->invoice()->shouldReturn($invoice);

--- a/spec/Entity/TaxItemSpec.php
+++ b/spec/Entity/TaxItemSpec.php
@@ -20,28 +20,28 @@ use Sylius\InvoicingPlugin\Entity\TaxItemInterface;
 
 final class TaxItemSpec extends ObjectBehavior
 {
-    public function let(): void
+    function let(): void
     {
         $this->beConstructedWith('VAT (23%)', 2300);
     }
 
-    public function it_implements_tax_item_interface(): void
+    function it_implements_tax_item_interface(): void
     {
         $this->shouldImplement(TaxItemInterface::class);
     }
 
-    public function it_implements_resource_interface(): void
+    function it_implements_resource_interface(): void
     {
         $this->shouldImplement(ResourceInterface::class);
     }
 
-    public function it_has_proper_tax_item_data(): void
+    function it_has_proper_tax_item_data(): void
     {
         $this->label()->shouldReturn('VAT (23%)');
         $this->amount()->shouldReturn(2300);
     }
 
-    public function it_has_an_invoice(InvoiceInterface $invoice): void
+    function it_has_an_invoice(InvoiceInterface $invoice): void
     {
         $this->setInvoice($invoice);
         $this->invoice()->shouldReturn($invoice);

--- a/spec/Event/OrderPaymentPaidSpec.php
+++ b/spec/Event/OrderPaymentPaidSpec.php
@@ -17,7 +17,7 @@ use PhpSpec\ObjectBehavior;
 
 final class OrderPaymentPaidSpec extends ObjectBehavior
 {
-    public function it_represents_an_immutable_fact_that_payment_related_to_order_was_completed(): void
+    function it_represents_an_immutable_fact_that_payment_related_to_order_was_completed(): void
     {
         $date = new \DateTimeImmutable('now');
 

--- a/spec/Event/OrderPlacedSpec.php
+++ b/spec/Event/OrderPlacedSpec.php
@@ -17,7 +17,7 @@ use PhpSpec\ObjectBehavior;
 
 final class OrderPlacedSpec extends ObjectBehavior
 {
-    public function it_represents_an_immutable_fact_that_an_order_has_been_placed(): void
+    function it_represents_an_immutable_fact_that_an_order_has_been_placed(): void
     {
         $date = new \DateTimeImmutable();
 

--- a/spec/EventListener/CreateInvoiceOnOrderPlacedListenerSpec.php
+++ b/spec/EventListener/CreateInvoiceOnOrderPlacedListenerSpec.php
@@ -19,12 +19,12 @@ use Sylius\InvoicingPlugin\Event\OrderPlaced;
 
 final class CreateInvoiceOnOrderPlacedListenerSpec extends ObjectBehavior
 {
-    public function let(InvoiceCreatorInterface $invoiceCreator): void
+    function let(InvoiceCreatorInterface $invoiceCreator): void
     {
         $this->beConstructedWith($invoiceCreator);
     }
 
-    public function it_requests_invoice_creation(InvoiceCreatorInterface $invoiceCreator): void
+    function it_requests_invoice_creation(InvoiceCreatorInterface $invoiceCreator): void
     {
         $issuedAt = new \DateTimeImmutable();
 

--- a/spec/EventListener/OrderPaymentPaidListenerSpec.php
+++ b/spec/EventListener/OrderPaymentPaidListenerSpec.php
@@ -21,12 +21,12 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 final class OrderPaymentPaidListenerSpec extends ObjectBehavior
 {
-    public function let(MessageBusInterface $commandBus): void
+    function let(MessageBusInterface $commandBus): void
     {
         $this->beConstructedWith($commandBus);
     }
 
-    public function it_dispatches_send_invoice_email_command(MessageBusInterface $commandBus): void
+    function it_dispatches_send_invoice_email_command(MessageBusInterface $commandBus): void
     {
         $command = new SendInvoiceEmail('00000001');
         $commandBus->dispatch($command)->shouldBeCalled()->willReturn(new Envelope($command));

--- a/spec/EventProducer/OrderPaymentPaidProducerSpec.php
+++ b/spec/EventProducer/OrderPaymentPaidProducerSpec.php
@@ -26,7 +26,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 final class OrderPaymentPaidProducerSpec extends ObjectBehavior
 {
-    public function let(
+    function let(
         MessageBusInterface $eventBus,
         DateTimeProvider $dateTimeProvider,
         InvoiceRepositoryInterface $invoiceRepository
@@ -34,7 +34,7 @@ final class OrderPaymentPaidProducerSpec extends ObjectBehavior
         $this->beConstructedWith($eventBus, $dateTimeProvider, $invoiceRepository);
     }
 
-    public function it_dispatches_order_payment_paid_event_for_payment(
+    function it_dispatches_order_payment_paid_event_for_payment(
         MessageBusInterface $eventBus,
         DateTimeProvider $dateTimeProvider,
         PaymentInterface $payment,
@@ -57,7 +57,7 @@ final class OrderPaymentPaidProducerSpec extends ObjectBehavior
         $this->__invoke($payment);
     }
 
-    public function it_does_not_dispatch_event_when_payment_is_not_related_to_order(
+    function it_does_not_dispatch_event_when_payment_is_not_related_to_order(
         MessageBusInterface $eventBus,
         DateTimeProvider $dateTimeProvider,
         PaymentInterface $payment
@@ -71,7 +71,7 @@ final class OrderPaymentPaidProducerSpec extends ObjectBehavior
         $this->__invoke($payment);
     }
 
-    public function it_does_not_dispatch_event_when_there_is_no_invoice_related_to_order(
+    function it_does_not_dispatch_event_when_there_is_no_invoice_related_to_order(
         MessageBusInterface $eventBus,
         DateTimeProvider $dateTimeProvider,
         PaymentInterface $payment,

--- a/spec/EventProducer/OrderPlacedProducerSpec.php
+++ b/spec/EventProducer/OrderPlacedProducerSpec.php
@@ -30,12 +30,12 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 final class OrderPlacedProducerSpec extends ObjectBehavior
 {
-    public function let(MessageBusInterface $eventBus, DateTimeProvider $dateTimeProvider): void
+    function let(MessageBusInterface $eventBus, DateTimeProvider $dateTimeProvider): void
     {
         $this->beConstructedWith($eventBus, $dateTimeProvider);
     }
 
-    public function it_dispatches_an_order_placed_event_for_persisted_order(
+    function it_dispatches_an_order_placed_event_for_persisted_order(
         MessageBusInterface $eventBus,
         DateTimeProvider $dateTimeProvider,
         OrderInterface $order,
@@ -55,7 +55,7 @@ final class OrderPlacedProducerSpec extends ObjectBehavior
         $this->postPersist($postPersistEvent);
     }
 
-    public function it_dispatches_an_order_placed_event_for_updated_order(
+    function it_dispatches_an_order_placed_event_for_updated_order(
         MessageBusInterface $eventBus,
         DateTimeProvider $dateTimeProvider,
         EntityManagerInterface $entityManager,
@@ -82,7 +82,7 @@ final class OrderPlacedProducerSpec extends ObjectBehavior
         $this->postUpdate($postUpdateEvent);
     }
 
-    public function it_does_nothing_after_persisting_if_event_entity_is_not_order(
+    function it_does_nothing_after_persisting_if_event_entity_is_not_order(
         MessageBusInterface $eventBus,
         LifecycleEventArgs $event
     ): void {
@@ -93,7 +93,7 @@ final class OrderPlacedProducerSpec extends ObjectBehavior
         $this->postPersist($event);
     }
 
-    public function it_does_nothing_after_update_if_event_entity_is_not_order(
+    function it_does_nothing_after_update_if_event_entity_is_not_order(
         MessageBusInterface $eventBus,
         LifecycleEventArgs $event
     ): void {
@@ -104,7 +104,7 @@ final class OrderPlacedProducerSpec extends ObjectBehavior
         $this->postUpdate($event);
     }
 
-    public function it_does_nothing_after_persisting_if_order_is_not_completed(
+    function it_does_nothing_after_persisting_if_order_is_not_completed(
         MessageBusInterface $eventBus,
         LifecycleEventArgs $event,
         OrderInterface $order
@@ -118,7 +118,7 @@ final class OrderPlacedProducerSpec extends ObjectBehavior
         $this->postPersist($event);
     }
 
-    public function it_does_nothing_after_update_if_order_checkout_state_has_not_changed(
+    function it_does_nothing_after_update_if_order_checkout_state_has_not_changed(
         MessageBusInterface $eventBus,
         LifecycleEventArgs $event,
         EntityManagerInterface $entityManager,
@@ -139,7 +139,7 @@ final class OrderPlacedProducerSpec extends ObjectBehavior
         $this->postUpdate($event);
     }
 
-    public function it_does_nothing_after_update_if_order_checkout_state_has_not_changed_to_completed(
+    function it_does_nothing_after_update_if_order_checkout_state_has_not_changed_to_completed(
         MessageBusInterface $eventBus,
         LifecycleEventArgs $event,
         EntityManagerInterface $entityManager,

--- a/spec/Factory/InvoiceFactorySpec.php
+++ b/spec/Factory/InvoiceFactorySpec.php
@@ -24,12 +24,12 @@ use Sylius\InvoicingPlugin\Factory\InvoiceFactoryInterface;
 
 class InvoiceFactorySpec extends ObjectBehavior
 {
-    public function it_implements_invoice_factory_interface(): void
+    function it_implements_invoice_factory_interface(): void
     {
         $this->shouldImplement(InvoiceFactoryInterface::class);
     }
 
-    public function it_creates_an_invoice_for_given_data(
+    function it_creates_an_invoice_for_given_data(
         BillingDataInterface $billingData,
         ChannelInterface $channel,
         InvoiceShopBillingDataInterface $invoiceShopBillingData,
@@ -53,7 +53,7 @@ class InvoiceFactorySpec extends ObjectBehavior
         )->shouldReturnAnInstanceOf(InvoiceInterface::class);
     }
 
-    public function it_allows_for_nullable_shop_billing_data(
+    function it_allows_for_nullable_shop_billing_data(
         BillingDataInterface $billingData,
         ChannelInterface $channel,
         OrderInterface $order

--- a/spec/Generator/InvoiceGeneratorSpec.php
+++ b/spec/Generator/InvoiceGeneratorSpec.php
@@ -32,7 +32,7 @@ use Sylius\InvoicingPlugin\Generator\InvoiceNumberGenerator;
 
 final class InvoiceGeneratorSpec extends ObjectBehavior
 {
-    public function let(
+    function let(
         InvoiceIdentifierGenerator $uuidInvoiceIdentifierGenerator,
         InvoiceNumberGenerator $sequentialInvoiceNumberGenerator,
         InvoiceFactoryInterface $invoiceFactory,
@@ -52,12 +52,12 @@ final class InvoiceGeneratorSpec extends ObjectBehavior
         );
     }
 
-    public function it_is_an_invoice_generator(): void
+    function it_is_an_invoice_generator(): void
     {
         $this->shouldImplement(InvoiceGeneratorInterface::class);
     }
 
-    public function it_generates_an_invoice_for_a_given_order(
+    function it_generates_an_invoice_for_a_given_order(
         InvoiceIdentifierGenerator $uuidInvoiceIdentifierGenerator,
         InvoiceNumberGenerator $sequentialInvoiceNumberGenerator,
         InvoiceFactoryInterface $invoiceFactory,

--- a/spec/Generator/InvoicePdfFileGeneratorSpec.php
+++ b/spec/Generator/InvoicePdfFileGeneratorSpec.php
@@ -25,7 +25,7 @@ use Twig\Environment;
 
 final class InvoicePdfFileGeneratorSpec extends ObjectBehavior
 {
-    public function let(
+    function let(
         Environment $twig,
         GeneratorInterface $pdfGenerator,
         FileLocatorInterface $fileLocator,
@@ -41,12 +41,12 @@ final class InvoicePdfFileGeneratorSpec extends ObjectBehavior
         );
     }
 
-    public function it_implements_invoice_pdf_file_generator_interface(): void
+    function it_implements_invoice_pdf_file_generator_interface(): void
     {
         $this->shouldImplement(InvoicePdfFileGeneratorInterface::class);
     }
 
-    public function it_creates_invoice_pdf_with_generated_content_and_filename_basing_on_invoice_number(
+    function it_creates_invoice_pdf_with_generated_content_and_filename_basing_on_invoice_number(
         FileLocatorInterface $fileLocator,
         Environment $twig,
         GeneratorInterface $pdfGenerator,

--- a/spec/Generator/SequentialInvoiceNumberGeneratorSpec.php
+++ b/spec/Generator/SequentialInvoiceNumberGeneratorSpec.php
@@ -24,7 +24,7 @@ use Sylius\InvoicingPlugin\Generator\InvoiceNumberGenerator;
 
 final class SequentialInvoiceNumberGeneratorSpec extends ObjectBehavior
 {
-    public function let(
+    function let(
         RepositoryInterface $sequenceRepository,
         FactoryInterface $sequenceFactory,
         EntityManagerInterface $sequenceManager,
@@ -40,12 +40,12 @@ final class SequentialInvoiceNumberGeneratorSpec extends ObjectBehavior
         );
     }
 
-    public function it_implements_invoice_number_generator_interface(): void
+    function it_implements_invoice_number_generator_interface(): void
     {
         $this->shouldImplement(InvoiceNumberGenerator::class);
     }
 
-    public function it_generates_invoice_number(
+    function it_generates_invoice_number(
         RepositoryInterface $sequenceRepository,
         EntityManagerInterface $sequenceManager,
         DateTimeProvider $dateTimeProvider,
@@ -67,7 +67,7 @@ final class SequentialInvoiceNumberGeneratorSpec extends ObjectBehavior
         $this->generate()->shouldReturn($dateTime->format('Y/m') . '/000000001');
     }
 
-    public function it_generates_invoice_number_when_sequence_is_null(
+    function it_generates_invoice_number_when_sequence_is_null(
         RepositoryInterface $sequenceRepository,
         FactoryInterface $sequenceFactory,
         EntityManagerInterface $sequenceManager,

--- a/spec/Generator/UuidInvoiceIdentifierGeneratorSpec.php
+++ b/spec/Generator/UuidInvoiceIdentifierGeneratorSpec.php
@@ -18,17 +18,17 @@ use Sylius\InvoicingPlugin\Generator\InvoiceIdentifierGenerator;
 
 final class UuidInvoiceIdentifierGeneratorSpec extends ObjectBehavior
 {
-    public function it_is_an_invoice_identifier_generator(): void
+    function it_is_an_invoice_identifier_generator(): void
     {
         $this->shouldImplement(InvoiceIdentifierGenerator::class);
     }
 
-    public function it_returns_a_string(): void
+    function it_returns_a_string(): void
     {
         $this->generate()->shouldBeString();
     }
 
-    public function it_returns_two_different_strings_on_subsequent_calls(): void
+    function it_returns_two_different_strings_on_subsequent_calls(): void
     {
         $this->generate()->shouldNotReturn($this->generate());
     }

--- a/spec/Model/InvoicePdfSpec.php
+++ b/spec/Model/InvoicePdfSpec.php
@@ -17,17 +17,17 @@ use PhpSpec\ObjectBehavior;
 
 final class InvoicePdfSpec extends ObjectBehavior
 {
-    public function let(): void
+    function let(): void
     {
         $this->beConstructedWith('2018_01_0000002.pdf', 'pdf content');
     }
 
-    public function it_has_filename(): void
+    function it_has_filename(): void
     {
         $this->filename()->shouldReturn('2018_01_0000002.pdf');
     }
 
-    public function it_has_content(): void
+    function it_has_content(): void
     {
         $this->content()->shouldReturn('pdf content');
     }

--- a/spec/Provider/ChannelColorProviderSpec.php
+++ b/spec/Provider/ChannelColorProviderSpec.php
@@ -20,17 +20,17 @@ use Sylius\InvoicingPlugin\Provider\ChannelColorProviderInterface;
 
 final class ChannelColorProviderSpec extends ObjectBehavior
 {
-    public function let(ChannelRepositoryInterface $channelRepository): void
+    function let(ChannelRepositoryInterface $channelRepository): void
     {
         $this->beConstructedWith($channelRepository, 'whiteGrey');
     }
 
-    public function it_implements_channel_color_provider_interface(): void
+    function it_implements_channel_color_provider_interface(): void
     {
         $this->shouldImplement(ChannelColorProviderInterface::class);
     }
 
-    public function it_returns_channel_color(
+    function it_returns_channel_color(
         ChannelRepositoryInterface $channelRepository,
         ChannelInterface $channel
     ): void {
@@ -40,7 +40,7 @@ final class ChannelColorProviderSpec extends ObjectBehavior
         $this->provide('en_US')->shouldReturn('black');
     }
 
-    public function it_returns_default_channel_color_if_channel_does_not_provide_one(
+    function it_returns_default_channel_color_if_channel_does_not_provide_one(
         ChannelRepositoryInterface $channelRepository,
         ChannelInterface $channel
     ): void {

--- a/spec/Security/Voter/InvoiceVoterSpec.php
+++ b/spec/Security/Voter/InvoiceVoterSpec.php
@@ -26,32 +26,32 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class InvoiceVoterSpec extends ObjectBehavior
 {
-    public function let(OrderRepositoryInterface $orderRepository): void
+    function let(OrderRepositoryInterface $orderRepository): void
     {
         $this->beConstructedWith($orderRepository);
     }
 
-    public function it_is_a_symfony_security_voter(): void
+    function it_is_a_symfony_security_voter(): void
     {
         $this->shouldHaveType(VoterInterface::class);
     }
 
-    public function it_abstains_from_making_a_decision_if_attribute_is_not_supported(TokenInterface $token, InvoiceInterface $invoice): void
+    function it_abstains_from_making_a_decision_if_attribute_is_not_supported(TokenInterface $token, InvoiceInterface $invoice): void
     {
         $this->vote($token, $invoice, ['random'])->shouldReturn(VoterInterface::ACCESS_ABSTAIN);
     }
 
-    public function it_abstains_from_making_a_decision_if_subject_is_not_supported(TokenInterface $token): void
+    function it_abstains_from_making_a_decision_if_subject_is_not_supported(TokenInterface $token): void
     {
         $this->vote($token, new \stdClass(), [InvoiceVoter::ACCESS])->shouldReturn(VoterInterface::ACCESS_ABSTAIN);
     }
 
-    public function it_does_not_allow_accessing_an_invoice_if_user_is_not_logged_in(TokenInterface $token, InvoiceInterface $invoice): void
+    function it_does_not_allow_accessing_an_invoice_if_user_is_not_logged_in(TokenInterface $token, InvoiceInterface $invoice): void
     {
         $this->vote($token, $invoice, [InvoiceVoter::ACCESS])->shouldReturn(VoterInterface::ACCESS_DENIED);
     }
 
-    public function it_allows_accesings_an_invoice_if_user_is_logged_as_admin(
+    function it_allows_accesings_an_invoice_if_user_is_logged_as_admin(
         TokenInterface $token,
         InvoiceInterface $invoice,
         AdminUserInterface $adminUser
@@ -61,7 +61,7 @@ class InvoiceVoterSpec extends ObjectBehavior
         $this->vote($token, $invoice, [InvoiceVoter::ACCESS])->shouldReturn(VoterInterface::ACCESS_GRANTED);
     }
 
-    public function it_does_not_allow_accessing_an_invoice_if_user_has_not_placed_the_order_related_to_the_invoice(
+    function it_does_not_allow_accessing_an_invoice_if_user_has_not_placed_the_order_related_to_the_invoice(
         OrderRepositoryInterface $orderRepository,
         TokenInterface $token,
         InvoiceInterface $invoice,
@@ -79,7 +79,7 @@ class InvoiceVoterSpec extends ObjectBehavior
         $this->vote($token, $invoice, [InvoiceVoter::ACCESS])->shouldReturn(VoterInterface::ACCESS_DENIED);
     }
 
-    public function it_allows_accessing_an_invoice_if_user_has_placed_the_order_related_to_the_invoice(
+    function it_allows_accessing_an_invoice_if_user_has_placed_the_order_related_to_the_invoice(
         OrderRepositoryInterface $orderRepository,
         TokenInterface $token,
         InvoiceInterface $invoice,


### PR DESCRIPTION
According to the convention proposed by [PHPSpec itself](http://www.phpspec.net/en/stable/manual/getting-started.html#specifying-behaviour), as well as [convention on Sylius/Sylius repository](https://github.com/Sylius/Sylius/blob/master/ecs.php#L26).