### PR TITLE
Add existing condition to change AdminMenu

### DIFF
--- a/src/Ui/Menu/AdminMenuListener.php
+++ b/src/Ui/Menu/AdminMenuListener.php
@@ -24,11 +24,12 @@ final class AdminMenuListener
 
         /** @var ItemInterface $salesMenu */
         $salesMenu = $menu->getChild('sales');
-
-        $salesMenu
-            ->addChild('invoices', ['route' => 'sylius_invoicing_plugin_admin_invoice_index'])
-                ->setLabel('sylius_invoicing_plugin.ui.invoices')
-                ->setLabelAttribute('icon', 'file')
-        ;
+        if($salesMenu) {
+            $salesMenu
+                ->addChild('invoices', ['route' => 'sylius_invoicing_plugin_admin_invoice_index'])
+                    ->setLabel('sylius_invoicing_plugin.ui.invoices')
+                    ->setLabelAttribute('icon', 'file')
+            ;
+        }
     }
 }


### PR DESCRIPTION
Hi, 

I have multiple dashboards depending on the user's ROLE.
One of them has the salesMenu removed on my custom AdminMenuListener.

This worked fine before adding the invoice plugin but now that I have it enabled the AdminMenuListener from the bundle runs after my custom one where the sales menu is removed which triggers a 500 error `Call to a member function addChild() on null` adding this condition makes it work corectly for all my dashboards.