### PR TITLE
Fix sending emails when storing invoices in S3

### DIFF
--- a/src/Email/InvoiceEmailSender.php
+++ b/src/Email/InvoiceEmailSender.php
@@ -16,6 +16,7 @@ namespace Sylius\InvoicingPlugin\Email;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
 use Sylius\InvoicingPlugin\Provider\InvoiceFileProviderInterface;
+use Sylius\InvoicingPlugin\Filesystem\TemporaryFilesystem;
 
 final class InvoiceEmailSender implements InvoiceEmailSenderInterface
 {
@@ -25,12 +26,16 @@ final class InvoiceEmailSender implements InvoiceEmailSenderInterface
     /** @var InvoiceFileProviderInterface */
     private $invoiceFileProvider;
 
+    /** @var TemporaryFilesystem */
+    private $temporaryFilesystem;
+
     public function __construct(
         SenderInterface $emailSender,
         InvoiceFileProviderInterface $invoiceFileProvider
     ) {
         $this->emailSender = $emailSender;
         $this->invoiceFileProvider = $invoiceFileProvider;
+        $this->temporaryFilesystem = new TemporaryFilesystem();
     }
 
     public function sendInvoiceEmail(
@@ -39,9 +44,15 @@ final class InvoiceEmailSender implements InvoiceEmailSenderInterface
     ): void {
         $invoicePdf = $this->invoiceFileProvider->provide($invoice);
 
-        $this
-            ->emailSender
-            ->send(Emails::INVOICE_GENERATED, [$customerEmail], ['invoice' => $invoice], [$invoicePdf->fullPath()])
-        ;
+        // Since Sylius' Mailer does not support sending attachments which aren't real files
+        // we have to simulate the file being on the local filesystem, so that we save the PDF,
+        // run the callable and delete it when the callable is finished.
+        $this->temporaryFilesystem->executeWithFile(
+            $invoicePdf->filename(),
+            $invoicePdf->content(),
+            function (string $filepath) use ($invoice, $customerEmail): void {
+                $this->emailSender->send(Emails::INVOICE_GENERATED, [$customerEmail], ['invoice' => $invoice], [$filepath]);
+            }
+        );
     }
 }

--- a/src/Filesystem/TemporaryFilesystem.php
+++ b/src/Filesystem/TemporaryFilesystem.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Paweł Jędrzejewski
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\InvoicingPlugin\Filesystem;
+
+final class TemporaryFilesystem
+{
+    /** @var string */
+    private $targetDirectory;
+
+    public function __construct(?string $targetDirectory = null)
+    {
+        $this->targetDirectory = rtrim($targetDirectory ?? sys_get_temp_dir(), \DIRECTORY_SEPARATOR);
+    }
+
+    public function executeWithFile(string $filename, string $content, callable $callback): void
+    {
+        $filepath = $this->targetDirectory . \DIRECTORY_SEPARATOR . $filename;
+
+        if (!file_put_contents($filepath, $content)) {
+            throw new \RuntimeException(sprintf('Could not create file "%s"!', $filepath));
+        }
+
+        try {
+            $callback($filepath);
+        } finally {
+            unlink($filepath);
+        }
+    }
+}


### PR DESCRIPTION
Fixes:

```
Handling "Sylius\InvoicingPlugin\Event\OrderPaymentPaid" failed: Handling "Sylius\InvoicingPlugin\Command\SendInvoiceEmail" failed: Unable to open file for reading [/.../shop/private/invoices//2021_07_000000001.pdf]
```

Reason: when storing invoices on S3 the directory `/private/invoices` does not exist, so it is necassary to readd the TemporaryFilesystem and use it for sendending the invoice emal.