### PR TITLE
[Maintenance] Remove wrong return types

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,4 +12,6 @@ parameters:
 
     ignoreErrors:
         - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'
+        - '/Method Sylius\\InvoicingPlugin\\Entity\\\w+::id\(\) has no return typehint specified\./'
+        - '/Method Sylius\\InvoicingPlugin\\Entity\\\w+::getId\(\) has no return typehint specified\./'
         - '/expects string, string\|null given\.$/'

--- a/src/Entity/InvoiceShopBillingData.php
+++ b/src/Entity/InvoiceShopBillingData.php
@@ -18,7 +18,7 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 /** @final */
 class InvoiceShopBillingData implements InvoiceShopBillingDataInterface, ResourceInterface
 {
-    /** @var string */
+    /** @var mixed */
     protected $id;
 
     /** @var string|null */
@@ -42,7 +42,7 @@ class InvoiceShopBillingData implements InvoiceShopBillingDataInterface, Resourc
     /** @var string|null */
     protected $representative;
 
-    public function getId(): string
+    public function getId()
     {
         return $this->id;
     }

--- a/src/Entity/InvoiceShopBillingDataInterface.php
+++ b/src/Entity/InvoiceShopBillingDataInterface.php
@@ -15,7 +15,7 @@ namespace Sylius\InvoicingPlugin\Entity;
 
 interface InvoiceShopBillingDataInterface
 {
-    public function getId(): string;
+    public function getId();
 
     public function getTaxId(): ?string;
 

--- a/src/Entity/LineItem.php
+++ b/src/Entity/LineItem.php
@@ -19,7 +19,7 @@ use Sylius\InvoicingPlugin\Exception\LineItemsCannotBeMerged;
 /** @final */
 class LineItem implements LineItemInterface, ResourceInterface
 {
-    /** @var string */
+    /** @var mixed */
     protected $id;
 
     /** @var InvoiceInterface */
@@ -74,7 +74,7 @@ class LineItem implements LineItemInterface, ResourceInterface
         $this->taxRate = $taxRate;
     }
 
-    public function getId(): string
+    public function getId()
     {
         return $this->id();
     }

--- a/src/Entity/LineItemInterface.php
+++ b/src/Entity/LineItemInterface.php
@@ -15,7 +15,7 @@ namespace Sylius\InvoicingPlugin\Entity;
 
 interface LineItemInterface
 {
-    public function id(): string;
+    public function id();
 
     public function invoice(): InvoiceInterface;
 

--- a/src/Entity/TaxItem.php
+++ b/src/Entity/TaxItem.php
@@ -18,7 +18,7 @@ use Sylius\Component\Resource\Model\ResourceInterface;
 /** @final */
 class TaxItem implements TaxItemInterface, ResourceInterface
 {
-    /** @var string */
+    /** @var mixed */
     protected $id;
 
     /** @var InvoiceInterface */
@@ -36,7 +36,7 @@ class TaxItem implements TaxItemInterface, ResourceInterface
         $this->amount = $amount;
     }
 
-    public function getId(): string
+    public function getId()
     {
         return $this->id();
     }

--- a/src/Entity/TaxItemInterface.php
+++ b/src/Entity/TaxItemInterface.php
@@ -15,7 +15,7 @@ namespace Sylius\InvoicingPlugin\Entity;
 
 interface TaxItemInterface
 {
-    public function id(): string;
+    public function id();
 
     public function invoice(): InvoiceInterface;
 


### PR DESCRIPTION
These ids were integers for years already
https://github.com/Sylius/InvoicingPlugin/blob/93a4fa83b89b0a10ce6fde34807e0a9074524892/src/Resources/config/doctrine/InvoiceShopBillingData.orm.xml#L10-L12
https://github.com/Sylius/InvoicingPlugin/blob/93a4fa83b89b0a10ce6fde34807e0a9074524892/src/Resources/config/doctrine/LineItem.orm.xml#L5-L7
https://github.com/Sylius/InvoicingPlugin/blob/93a4fa83b89b0a10ce6fde34807e0a9074524892/src/Resources/config/doctrine/TaxItem.orm.xml#L5-L7