### PR TITLE
Fix invoice payment state not updating when given order is paid

### DIFF
--- a/spec/Generator/InvoiceGeneratorSpec.php
+++ b/spec/Generator/InvoiceGeneratorSpec.php
@@ -18,7 +18,7 @@ use PhpSpec\ObjectBehavior;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\InvoicingPlugin\Converter\LineItemsConverterInterface;
 use Sylius\InvoicingPlugin\Converter\TaxItemsConverterInterface;
 use Sylius\InvoicingPlugin\Entity\BillingData;
@@ -90,7 +90,7 @@ final class InvoiceGeneratorSpec extends ObjectBehavior
         $order->getLocaleCode()->willReturn('en_US');
         $order->getTotal()->willReturn(10300);
         $order->getChannel()->willReturn($channel);
-        $order->getPaymentState()->willReturn(PaymentInterface::STATE_COMPLETED);
+        $order->getPaymentState()->willReturn(OrderPaymentStates::STATE_PAID);
         $order->getBillingAddress()->willReturn($billingAddress);
 
         $billingDataFactory->createFromAddress($billingAddress)->willReturn($billingData);

--- a/src/Generator/InvoiceGenerator.php
+++ b/src/Generator/InvoiceGenerator.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Sylius\Component\Core\Model\AddressInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
-use Sylius\Component\Payment\Model\PaymentInterface;
+use Sylius\Component\Core\OrderPaymentStates;
 use Sylius\InvoicingPlugin\Converter\LineItemsConverterInterface;
 use Sylius\InvoicingPlugin\Converter\TaxItemsConverterInterface;
 use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
@@ -71,7 +71,7 @@ final class InvoiceGenerator implements InvoiceGeneratorInterface
         /** @var ChannelInterface $channel */
         $channel = $order->getChannel();
 
-        $paymentState = $order->getPaymentState() === PaymentInterface::STATE_COMPLETED ?
+        $paymentState = $order->getPaymentState() === OrderPaymentStates::STATE_PAID ?
             InvoiceInterface::PAYMENT_STATE_COMPLETED : InvoiceInterface::PAYMENT_STATE_PENDING;
 
         return $this->invoiceFactory->createForData(


### PR DESCRIPTION
Change conditions settings Invoice Payment state.

`$order->getPaymentState()` is returning a string from `OrderPaymentStates`, therefore Invoice status is never set to `'completed'`