### PR TITLE
fix: compare when name is the same but not variant

### DIFF
--- a/spec/Entity/LineItemSpec.php
+++ b/spec/Entity/LineItemSpec.php
@@ -93,17 +93,26 @@ final class LineItemSpec extends ObjectBehavior
 
     public function it_compares_with_another_line_item(
         LineItemInterface $theSameLineItem,
-        LineItemInterface $differentLineItem
+        LineItemInterface $differentLineItemName,
+        LineItemInterface $differentLineItemCode
     ): void {
         $theSameLineItem->name()->willReturn('Mjolnir');
         $theSameLineItem->unitPrice()->willReturn(5000);
         $theSameLineItem->taxRate()->willReturn('10%');
+        $theSameLineItem->variantCode()->willReturn('7903c83a-4c5e-4bcf-81d8-9dc304c6a353');
 
-        $differentLineItem->name()->willReturn('Stormbreaker');
-        $differentLineItem->unitPrice()->willReturn(5000);
-        $differentLineItem->taxRate()->willReturn('10%');
+        $differentLineItemName->name()->willReturn('Stormbreaker');
+        $differentLineItemName->unitPrice()->willReturn(5000);
+        $differentLineItemName->taxRate()->willReturn('10%');
+        $differentLineItemName->variantCode()->willReturn('7903c83a-4c5e-4bcf-81d8-9dc304c6a353');
+
+        $differentLineItemCode->name()->willReturn('Mjolnir');
+        $differentLineItemCode->unitPrice()->willReturn(5000);
+        $differentLineItemCode->taxRate()->willReturn('10%');
+        $differentLineItemCode->variantCode()->willReturn('7903c83a-4c5e-4bcf-81d8-9dc304c6a350');
 
         $this->compare($theSameLineItem)->shouldReturn(true);
-        $this->compare($differentLineItem)->shouldReturn(false);
+        $this->compare($differentLineItemName)->shouldReturn(false);
+        $this->compare($differentLineItemCode)->shouldReturn(false);
     }
 }

--- a/spec/Entity/LineItemSpec.php
+++ b/spec/Entity/LineItemSpec.php
@@ -73,6 +73,7 @@ final class LineItemSpec extends ObjectBehavior
         $newLineItem->total()->willReturn(5500);
         $newLineItem->taxTotal()->willReturn(500);
         $newLineItem->taxRate()->willReturn('10%');
+        $newLineItem->variantCode()->willReturn('7903c83a-4c5e-4bcf-81d8-9dc304c6a353');
 
         $this->merge($newLineItem);
 

--- a/src/Entity/LineItem.php
+++ b/src/Entity/LineItem.php
@@ -145,6 +145,7 @@ class LineItem implements LineItemInterface, ResourceInterface
     {
         return
             $this->name() === $lineItem->name() &&
+            $this->variantCode() === $lineItem->variantCode() &&
             $this->unitPrice() === $lineItem->unitPrice() &&
             $this->taxRate() === $lineItem->taxRate()
         ;


### PR DESCRIPTION
When the name, price and tax are the same whereas the variant is not the same, it's merged. The fix compare the variant to be sure.