### PR TITLE
[DependencyInjection] Move registering resources to prepend method

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,7 +11,6 @@ parameters:
         - 'tests/Application/src/**.php'
 
     ignoreErrors:
-        - '/Parameter #1 \$configuration of method Symfony\\Component\\DependencyInjection\\Extension\\Extension::processConfiguration\(\) expects Symfony\\Component\\Config\\Definition\\ConfigurationInterface, Symfony\\Component\\Config\\Definition\\ConfigurationInterface\|null given\./'
         - '/Method Sylius\\InvoicingPlugin\\Entity\\\w+::id\(\) has no return typehint specified\./'
         - '/Method Sylius\\InvoicingPlugin\\Entity\\\w+::getId\(\) has no return typehint specified\./'
         - '/expects string, string\|null given\.$/'

--- a/src/DependencyInjection/SyliusInvoicingExtension.php
+++ b/src/DependencyInjection/SyliusInvoicingExtension.php
@@ -28,14 +28,18 @@ final class SyliusInvoicingExtension extends AbstractResourceExtension implement
     public function load(array $config, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
-
         $loader->load('services.xml');
+
+        /** @var ConfigurationInterface $configuration */
+        $configuration = $this->getConfiguration([], $container);
+
+        $config = $this->processConfiguration($configuration, $config);
+        $container->setParameter('sylius_invoicing.pdf_generator.allowed_files', $config['pdf_generator']['allowed_files']);
     }
 
     public function prepend(ContainerBuilder $container): void
     {
         $config = $this->getCurrentConfiguration($container);
-        $container->setParameter('sylius_invoicing.pdf_generator.allowed_files', $config['pdf_generator']['allowed_files']);
 
         $this->registerResources('sylius_invoicing_plugin', 'doctrine/orm', $config['resources'], $container);
 

--- a/src/DependencyInjection/SyliusInvoicingExtension.php
+++ b/src/DependencyInjection/SyliusInvoicingExtension.php
@@ -15,6 +15,7 @@ namespace Sylius\InvoicingPlugin\DependencyInjection;
 
 use Sylius\Bundle\CoreBundle\DependencyInjection\PrependDoctrineMigrationsTrait;
 use Sylius\Bundle\ResourceBundle\DependencyInjection\Extension\AbstractResourceExtension;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
@@ -26,18 +27,18 @@ final class SyliusInvoicingExtension extends AbstractResourceExtension implement
 
     public function load(array $config, ContainerBuilder $container): void
     {
-        $config = $this->processConfiguration($this->getConfiguration([], $container), $config);
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
 
-        $this->registerResources('sylius_invoicing_plugin', 'doctrine/orm', $config['resources'], $container);
-
         $loader->load('services.xml');
-
-        $container->setParameter('sylius_invoicing.pdf_generator.allowed_files', $config['pdf_generator']['allowed_files']);
     }
 
     public function prepend(ContainerBuilder $container): void
     {
+        $config = $this->getCurrentConfiguration($container);
+        $container->setParameter('sylius_invoicing.pdf_generator.allowed_files', $config['pdf_generator']['allowed_files']);
+
+        $this->registerResources('sylius_invoicing_plugin', 'doctrine/orm', $config['resources'], $container);
+
         $this->prependDoctrineMigrations($container);
     }
 
@@ -54,5 +55,15 @@ final class SyliusInvoicingExtension extends AbstractResourceExtension implement
     protected function getNamespacesOfMigrationsExecutedBefore(): array
     {
         return ['Sylius\Bundle\CoreBundle\Migrations'];
+    }
+
+    private function getCurrentConfiguration(ContainerBuilder $container): array
+    {
+        /** @var ConfigurationInterface $configuration */
+        $configuration = $this->getConfiguration([], $container);
+
+        $configs = $container->getExtensionConfig($this->getAlias());
+
+        return $this->processConfiguration($configuration, $configs);
     }
 }

--- a/src/Resources/config/config.yml
+++ b/src/Resources/config/config.yml
@@ -35,7 +35,7 @@ sylius_grid:
             driver:
                 name: doctrine/orm
                 options:
-                    class: 'expr:parameter("sylius_invoicing_plugin.model.invoice.class")'
+                    class: '%sylius_invoicing_plugin.model.invoice.class%'
             sorting:
                 issuedAt: desc
             fields:

--- a/tests/DependencyInjection/SyliusInvoicingExtensionTest.php
+++ b/tests/DependencyInjection/SyliusInvoicingExtensionTest.php
@@ -81,14 +81,9 @@ class SyliusInvoicingExtensionTest extends AbstractExtensionTestCase
     }
 
     /** @test */
-    public function it_prepends_configuration_with_allowed_files_for_pdf_generator(): void
+    public function it_loads_allowed_files_for_pdf_generator_configuration(): void
     {
-        $this->container->prependExtensionConfig(
-            'sylius_invoicing',
-            ['pdf_generator' => ['allowed_files' => ['swans.png', 'product.png']]]
-        );
-
-        $this->prepend();
+        $this->load(['pdf_generator' => ['allowed_files' => ['swans.png', 'product.png']]]);
 
         $this->assertContainerBuilderHasParameter(
             'sylius_invoicing.pdf_generator.allowed_files',

--- a/tests/DependencyInjection/SyliusInvoicingExtensionTest.php
+++ b/tests/DependencyInjection/SyliusInvoicingExtensionTest.php
@@ -14,22 +14,26 @@ declare(strict_types=1);
 namespace Tests\Sylius\InvoicingPlugin\DependencyInjection;
 
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension;
-use FOS\OAuthServerBundle\DependencyInjection\FOSOAuthServerExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Sylius\Bundle\ResourceBundle\Controller\ResourceController;
 use Sylius\InvoicingPlugin\DependencyInjection\SyliusInvoicingExtension;
+use Sylius\InvoicingPlugin\Entity\BillingData;
+use Sylius\InvoicingPlugin\Entity\Invoice;
+use Sylius\InvoicingPlugin\Entity\InvoiceSequence;
+use Sylius\InvoicingPlugin\Entity\InvoiceShopBillingData;
+use Sylius\InvoicingPlugin\Entity\LineItem;
+use Sylius\InvoicingPlugin\Entity\TaxItem;
 use SyliusLabs\DoctrineMigrationsExtraBundle\DependencyInjection\SyliusLabsDoctrineMigrationsExtraExtension;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 
 class SyliusInvoicingExtensionTest extends AbstractExtensionTestCase
 {
-    /**
-     * @test
-     */
+    /** @test */
     public function it_autoconfigures_prepending_doctrine_migration_with_proper_migrations_paths(): void
     {
         $this->configureContainer();
 
-        $this->customLoad();
+        $this->prepend();
 
         $doctrineMigrationsExtensionConfig = $this->container->getExtensionConfig('doctrine_migrations');
 
@@ -55,16 +59,14 @@ class SyliusInvoicingExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    /** @test */
     public function it_does_not_autoconfigure_prepending_doctrine_migrations_if_it_is_disabled(): void
     {
         $this->configureContainer();
 
         $this->container->setParameter('sylius_core.prepend_doctrine_migrations', false);
 
-        $this->customLoad();
+        $this->prepend();
 
         $doctrineMigrationsExtensionConfig = $this->container->getExtensionConfig('doctrine_migrations');
 
@@ -76,6 +78,118 @@ class SyliusInvoicingExtensionTest extends AbstractExtensionTestCase
         ;
 
         self::assertEmpty($syliusLabsDoctrineMigrationsExtraExtensionConfig);
+    }
+
+    /** @test */
+    public function it_prepends_configuration_with_allowed_files_for_pdf_generator(): void
+    {
+        $this->container->prependExtensionConfig(
+            'sylius_invoicing',
+            ['pdf_generator' => ['allowed_files' => ['swans.png', 'product.png']]]
+        );
+
+        $this->prepend();
+
+        $this->assertContainerBuilderHasParameter(
+            'sylius_invoicing.pdf_generator.allowed_files',
+            ['swans.png', 'product.png']
+        );
+    }
+
+    /** @test */
+    public function it_prepends_configuration_with_invoice_resource_services(): void
+    {
+        $this->prepend();
+
+        $this->assertContainerBuilderHasParameter(
+            'sylius_invoicing_plugin.model.invoice.class',
+            Invoice::class
+        );
+
+        $this->assertContainerBuilderHasService(
+            'sylius_invoicing_plugin.controller.invoice',
+            ResourceController::class
+        );
+    }
+
+    /** @test */
+    public function it_prepends_configuration_with_billing_data_resource_services(): void
+    {
+        $this->prepend();
+
+        $this->assertContainerBuilderHasParameter(
+            'sylius_invoicing_plugin.model.billing_data.class',
+            BillingData::class
+        );
+
+        $this->assertContainerBuilderHasService(
+            'sylius_invoicing_plugin.controller.billing_data',
+            ResourceController::class
+        );
+    }
+
+    /** @test */
+    public function it_prepends_configuration_with_shop_billing_data_resource_services(): void
+    {
+        $this->prepend();
+
+        $this->assertContainerBuilderHasParameter(
+            'sylius_invoicing_plugin.model.shop_billing_data.class',
+            InvoiceShopBillingData::class
+        );
+
+        $this->assertContainerBuilderHasService(
+            'sylius_invoicing_plugin.controller.shop_billing_data',
+            ResourceController::class
+        );
+    }
+
+    /** @test */
+    public function it_prepends_configuration_with_line_item_resource_services(): void
+    {
+        $this->prepend();
+
+        $this->assertContainerBuilderHasParameter(
+            'sylius_invoicing_plugin.model.line_item.class',
+            LineItem::class
+        );
+
+        $this->assertContainerBuilderHasService(
+            'sylius_invoicing_plugin.controller.line_item',
+            ResourceController::class
+        );
+    }
+
+    /** @test */
+    public function it_prepends_configuration_with_tax_item_resource_services(): void
+    {
+        $this->prepend();
+
+        $this->assertContainerBuilderHasParameter(
+            'sylius_invoicing_plugin.model.tax_item.class',
+            TaxItem::class
+        );
+
+        $this->assertContainerBuilderHasService(
+            'sylius_invoicing_plugin.controller.tax_item',
+            ResourceController::class
+        );
+    }
+
+    /** @test */
+    public function it_prepends_configuration_with_invoice_sequence_resource_services(): void
+    {
+        $this->prepend();
+
+        $this->assertContainerBuilderHasParameter(
+            'sylius_invoicing_plugin.model.invoice_sequence.class',
+            InvoiceSequence::class
+        );
+
+        $this->assertContainerBuilderHasService(
+            'sylius_invoicing_plugin.controller.invoice_sequence',
+            ResourceController::class
+        );
     }
 
     protected function getContainerExtensions(): array
@@ -90,25 +204,13 @@ class SyliusInvoicingExtensionTest extends AbstractExtensionTestCase
 
         $this->container->registerExtension(new DoctrineMigrationsExtension());
         $this->container->registerExtension(new SyliusLabsDoctrineMigrationsExtraExtension());
-        $this->container->registerExtension(new FOSOAuthServerExtension());
     }
 
-    private function customLoad(): void
+    private function prepend(): void
     {
-        $configurationValues = ['sylius_invoicing' => []];
-
-        $configs = [$this->getMinimalConfiguration(), $configurationValues];
-
         foreach ($this->container->getExtensions() as $extension) {
             if ($extension instanceof PrependExtensionInterface) {
                 $extension->prepend($this->container);
-            }
-        }
-
-        foreach ($this->container->getExtensions() as $extension) {
-            $extensionAlias = $extension->getAlias();
-            if (isset($configs[$extensionAlias])) {
-                $extension->load($configs[$extensionAlias], $this->container);
             }
         }
     }


### PR DESCRIPTION
Before this change, resources and their parameters were loaded too late and they cannot be used properly for example in a grid or state machine configuration.