### PR TITLE
[Maintenance] Allow flex plugin during plugin installation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,12 @@
         ]
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true,
+            "dealerdirect/phpcodesniffer-composer-installer": false,
+            "phpstan/extension-installer": true
+        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Follow up of https://github.com/Sylius/Sylius/pull/14106