### PR TITLE
Drop support for Sylius 1.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
             matrix:
                 php: ["8.0", "8.1"]
                 symfony: ["^4.4", "^5.4"]
-                sylius: ["~1.10.0", "~1.11.0"]
+                sylius: ["~1.11.0"]
                 node: ["14.x"]
                 mysql: ["5.7", "8.0"]
                 pdf: [true]

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "ramsey/uuid": "^3.9",
         "sylius/grid-bundle": "^1.7",
         "sylius/resource-bundle": "^1.6",
-        "sylius/sylius": "^1.10",
+        "sylius/sylius": "^1.11",
         "symfony/config": "^4.4 || ^5.4",
         "symfony/dependency-injection": "^4.4 || ^5.4",
         "symfony/form": "^4.4 || ^5.4",


### PR DESCRIPTION
As Sylius 1.10 is no longer maintained, I think it's high time to remove the support for it.