### PR TITLE
[symfony/workflow] Makes workflow event listener loading

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -2,7 +2,7 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <imports>
-        <import resource="services/**.xml" />
+        <import resource="services/**/*.xml" />
     </imports>
 
     <parameters>

--- a/src/Resources/config/services/listeners/workflow.xml
+++ b/src/Resources/config/services/listeners/workflow.xml
@@ -8,7 +8,7 @@
                  class="Sylius\InvoicingPlugin\EventListener\Workflow\Payment\ProduceOrderPaymentPaidListener">
             <argument type="service" id="sylius_invoicing_plugin.event_producer.order_payment_paid" />
 
-            <tag name="kernel.event_listener" event="workflow.sylius_payment.completed.complete" priority="100" />
+            <tag name="kernel.event_listener" event="workflow.sylius_payment.completed.complete" priority="50" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
The event listener for `symfony/workflow` can be loaded even if `winzou/state-machine` is still the default state machine.

Before this PR :

![image](https://github.com/user-attachments/assets/4a9fe8bc-e2cf-4887-a072-ae819c493ad9)
