### PR TITLE
Multiple invoice table row fix in shop order page

### DIFF
--- a/templates/shop/order/show/content/summary/invoices/card/body/table/body.html.twig
+++ b/templates/shop/order/show/content/summary/invoices/card/body/table/body.html.twig
@@ -1,7 +1,7 @@
 <tbody>
-    <tr>
-        {% for invoice in hookable_metadata.context.invoices %}
+    {% for invoice in hookable_metadata.context.invoices %}
+        <tr>
             {% hook 'body' with { invoice } %}
-        {% endfor %}
-    </tr>
+        </tr>
+    {% endfor %}
 </tbody>


### PR DESCRIPTION
If order has more than one invoice, 
rendering in shop order page is broken as all rows are placed inside one `<tr>` element instead of individual ones. 