### PR TITLE
Fix pdf invoice table spacer row column span

### DIFF
--- a/templates/shared/download/pdf.html.twig
+++ b/templates/shared/download/pdf.html.twig
@@ -68,7 +68,7 @@
         {% endfor %}
 
         <tr>
-            <td colspan="9" class="bg-gray border-0"></td>
+            <td colspan="10" class="bg-gray border-0"></td>
         </tr>
 
         <tr>


### PR DESCRIPTION
Before:

<img width="690" height="282" alt="Screenshot 2025-08-17 at 16 01 34" src="https://github.com/user-attachments/assets/84dbfed0-a075-42f4-9694-4272eeaae435" />

After:
<img width="690" height="282" alt="Screenshot 2025-08-17 at 16 03 43" src="https://github.com/user-attachments/assets/623c3f9c-4ce4-41aa-b7e6-2af892db43be" />
