### PR TITLE
[PDF] Fix separator in invoice pdf

### DIFF
--- a/templates/shared/download/pdf.html.twig
+++ b/templates/shared/download/pdf.html.twig
@@ -68,7 +68,7 @@
         {% endfor %}
 
         <tr>
-            <td colspan="9" class="bg-gray border-0"></td>
+            <td colspan="10" class="bg-gray border-0"></td>
         </tr>
 
         <tr>


### PR DESCRIPTION
### Description

This PR aims to fix the background of a cell above the net total in the invoice PDF.

#### Without the fix (Sylius demo site)
<img width="770" height="676" alt="image" src="https://github.com/user-attachments/assets/c879af40-c9c0-480a-906d-982834ec438c" />

#### After fixing the PDF (custom project)
<img width="712" height="121" alt="image" src="https://github.com/user-attachments/assets/863afb75-5002-4c27-9c55-85b7d5485a71" />

