### PR TITLE
Fix incorrect flash message type on invoice resend action

### DIFF
--- a/src/Ui/Action/Admin/ResendInvoiceAction.php
+++ b/src/Ui/Action/Admin/ResendInvoiceAction.php
@@ -54,7 +54,7 @@ final class ResendInvoiceAction
         try {
             $this->invoiceEmailSender->sendInvoiceEmail($invoice, $customer->getEmail());
         } catch (\Exception $exception) {
-            $this->getFlashBag()->add('failure', $exception->getMessage());
+            $this->getFlashBag()->add('error', $exception->getMessage());
 
             return new RedirectResponse(
                 $this->urlGenerator->generate('sylius_admin_order_show', ['id' => $order->getId()]),


### PR DESCRIPTION
When resending an invoice from the admin, the error flash message is not currently displayed