### PR TITLE
Add invoices column to orders grid

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -102,6 +102,15 @@ sylius_grid:
                                 parameters:
                                     id: resource.id
 
+        sylius_shop_account_order:
+            fields:
+                invoices:
+                    type: twig
+                    label: sylius_invoicing.ui.invoices
+                    path: .
+                    options:
+                        template: "@SyliusInvoicingPlugin/shop/account/order/grid/field/invoices.html.twig"
+
 framework:
     messenger:
         buses:

--- a/config/services/twig.xml
+++ b/config/services/twig.xml
@@ -11,6 +11,12 @@
 
 <container xmlns="http://symfony.com/schema/dic/services" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
     <services>
+        <service id="sylius_invoicing.twig.extension.invoices" class="Sylius\InvoicingPlugin\Twig\InvoicesExtension">
+            <argument type="service" id="sylius_invoicing.repository.invoice" />
+            <argument>%sylius_invoicing.pdf_generator.enabled%</argument>
+            <tag name="twig.extension" />
+        </service>
+
         <service
                 id="sylius_invoicing.twig.component.invoice.list"
                 class="Sylius\InvoicingPlugin\Twig\Component\Invoice\ListComponent"

--- a/features/managing_invoices/pdf_generation_disabled/showing_plain_invoice_numbers_on_orders_list_when_PDF_is_disabled.feature
+++ b/features/managing_invoices/pdf_generation_disabled/showing_plain_invoice_numbers_on_orders_list_when_PDF_is_disabled.feature
@@ -1,0 +1,22 @@
+@customer_browsing_invoices
+Feature: Showing plain invoice numbers on orders list when PDF is disabled
+    In order not to expose download links when PDF generation is disabled
+    As a Customer
+    I should see invoice numbers without links on the orders list
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Angel T-Shirt"
+        And the store ships everywhere for free
+        And the store allows paying with "Cash on Delivery"
+        And I am a logged in customer
+        And I placed an order "#00000666"
+        And I bought a single "Angel T-Shirt"
+        And I addressed it to "Lucifer Morningstar", "Seaside Fwy", "90802" "Los Angeles" in the "United States"
+        And for the billing address of "Mazikeen Lilim" in the "Pacific Coast Hwy", "90806" "Los Angeles", "United States"
+        And I chose "Free" shipping method with "Cash on Delivery" payment
+
+    @ui @pdf_disabled
+    Scenario: Invoice numbers are not links on orders list
+        When I browse my orders
+        Then I should not be able to download an invoice from my orders list

--- a/features/managing_invoices/pdf_generation_enabled/showing_invoice_links_on_orders_list_when_PDF_is_enabled.feature
+++ b/features/managing_invoices/pdf_generation_enabled/showing_invoice_links_on_orders_list_when_PDF_is_enabled.feature
@@ -1,0 +1,22 @@
+@customer_browsing_invoices
+Feature: Showing invoice links on orders list when PDF is enabled
+    In order to download invoices directly from my orders list
+    As a Customer
+    I should see clickable invoice numbers when PDF generation is enabled
+
+    Background:
+        Given the store operates on a single channel in "United States"
+        And the store has a product "Angel T-Shirt"
+        And the store ships everywhere for free
+        And the store allows paying with "Cash on Delivery"
+        And I am a logged in customer
+        And I placed an order "#00000666"
+        And I bought a single "Angel T-Shirt"
+        And I addressed it to "Lucifer Morningstar", "Seaside Fwy", "90802" "Los Angeles" in the "United States"
+        And for the billing address of "Mazikeen Lilim" in the "Pacific Coast Hwy", "90806" "Los Angeles", "United States"
+        And I chose "Free" shipping method with "Cash on Delivery" payment
+
+    @ui @pdf_enabled
+    Scenario: Invoice numbers are links on orders list
+        When I browse my orders
+        Then I should be able to download an invoice from my orders list

--- a/src/Twig/InvoicesExtension.php
+++ b/src/Twig/InvoicesExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\InvoicingPlugin\Twig;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepositoryInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class InvoicesExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly InvoiceRepositoryInterface $invoiceRepository,
+        private readonly bool $pdfEnabled = true,
+    )
+    {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('invoices_for_order', $this->invoicesForOrder(...)),
+            new TwigFunction('invoices_pdf_enabled', $this->isPdfEnabled(...)),
+        ];
+    }
+
+    public function invoicesForOrder(OrderInterface $order): array
+    {
+        return $this->invoiceRepository->findByOrderNumber($order->getNumber());
+    }
+
+    public function isPdfEnabled(): bool
+    {
+        return $this->pdfEnabled;
+    }
+}

--- a/src/Twig/InvoicesExtension.php
+++ b/src/Twig/InvoicesExtension.php
@@ -23,8 +23,7 @@ final class InvoicesExtension extends AbstractExtension
     public function __construct(
         private readonly InvoiceRepositoryInterface $invoiceRepository,
         private readonly bool $pdfEnabled = true,
-    )
-    {
+    ) {
     }
 
     public function getFunctions(): array

--- a/templates/shop/account/order/grid/field/invoices.html.twig
+++ b/templates/shop/account/order/grid/field/invoices.html.twig
@@ -1,0 +1,17 @@
+{% set invoices = invoices_for_order(data) %}
+{% if invoices is empty %}
+    <span class="text-muted">—</span>
+{% else %}
+    {% set pdfEnabled = invoices_pdf_enabled() %}
+    {% for invoice in invoices %}
+        {% if pdfEnabled %}
+            <div>
+                <a href="{{ path('sylius_invoicing_shop_invoice_download', {'id': invoice.id}) }}" {{ sylius_test_html_attribute('invoice-link') }}>{{ invoice.number }}</a>
+            </div>
+        {% else %}
+            <div>
+                <span {{ sylius_test_html_attribute('invoice-number') }}>{{ invoice.number }}</span>
+            </div>
+        {% endif %}
+    {% endfor %}
+{% endif %}

--- a/templates/shop/account/order/grid/field/invoices.html.twig
+++ b/templates/shop/account/order/grid/field/invoices.html.twig
@@ -2,9 +2,9 @@
 {% if invoices is empty %}
     <span class="text-muted">—</span>
 {% else %}
-    {% set pdfEnabled = invoices_pdf_enabled() %}
+    {% set pdf_enabled = invoices_pdf_enabled() %}
     {% for invoice in invoices %}
-        {% if pdfEnabled %}
+        {% if pdf_enabled %}
             <div>
                 <a href="{{ path('sylius_invoicing_shop_invoice_download', {'id': invoice.id}) }}" {{ sylius_test_html_attribute('invoice-link') }}>{{ invoice.number }}</a>
             </div>

--- a/tests/Behat/Context/Ui/Shop/AccountContext.php
+++ b/tests/Behat/Context/Ui/Shop/AccountContext.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\InvoicingPlugin\Behat\Context\Ui\Shop;
+
+use Behat\Behat\Context\Context;
+use Tests\Sylius\InvoicingPlugin\Behat\Page\Shop\Account\Order\IndexPageInterface;
+use Webmozart\Assert\Assert;
+
+final class AccountContext implements Context
+{
+    public function __construct(private IndexPageInterface $orderIndexPage)
+    {
+    }
+
+    /**
+     * @Then I should be able to download an invoice from my orders list
+     */
+    public function iShouldBeAbleToDownloadAnInvoiceFromMyOrdersList(): void
+    {
+        Assert::true($this->orderIndexPage->hasInvoiceLinks());
+    }
+
+    /**
+     * @Then I should not be able to download an invoice from my orders list
+     */
+    public function iShouldNotBeAbleToDownloadAnInvoiceFromMyOrdersList(): void
+    {
+        Assert::true($this->orderIndexPage->hasPlainInvoiceNumbers());
+    }
+}

--- a/tests/Behat/Context/Ui/Shop/AccountContext.php
+++ b/tests/Behat/Context/Ui/Shop/AccountContext.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Sylius\InvoicingPlugin\Behat\Context\Ui\Shop;
 
 use Behat\Behat\Context\Context;
+use Behat\Step\Then;
 use Tests\Sylius\InvoicingPlugin\Behat\Page\Shop\Account\Order\IndexPageInterface;
 use Webmozart\Assert\Assert;
 
@@ -23,17 +24,13 @@ final class AccountContext implements Context
     {
     }
 
-    /**
-     * @Then I should be able to download an invoice from my orders list
-     */
+    #[Then('I should be able to download an invoice from my orders list')]
     public function iShouldBeAbleToDownloadAnInvoiceFromMyOrdersList(): void
     {
         Assert::true($this->orderIndexPage->hasInvoiceLinks());
     }
 
-    /**
-     * @Then I should not be able to download an invoice from my orders list
-     */
+    #[Then('I should not be able to download an invoice from my orders list')]
     public function iShouldNotBeAbleToDownloadAnInvoiceFromMyOrdersList(): void
     {
         Assert::true($this->orderIndexPage->hasPlainInvoiceNumbers());

--- a/tests/Behat/Page/Shop/Account/Order/IndexPage.php
+++ b/tests/Behat/Page/Shop/Account/Order/IndexPage.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\InvoicingPlugin\Behat\Page\Shop\Account\Order;
+
+use Sylius\Behat\Page\Shop\Account\Order\IndexPage as BaseIndexPage;
+
+final class IndexPage extends BaseIndexPage implements IndexPageInterface
+{
+    public function hasInvoiceLinks(): bool
+    {
+        return $this->getDocument()->has('css', '[data-test-grid-table-body] [data-test-invoice-link]');
+    }
+
+    public function hasPlainInvoiceNumbers(): bool
+    {
+        return $this->getDocument()->has('css', '[data-test-grid-table-body] [data-test-invoice-number]');
+    }
+}

--- a/tests/Behat/Page/Shop/Account/Order/IndexPageInterface.php
+++ b/tests/Behat/Page/Shop/Account/Order/IndexPageInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\InvoicingPlugin\Behat\Page\Shop\Account\Order;
+
+use Sylius\Behat\Page\Shop\Account\Order\IndexPageInterface as BaseIndexPageInterface;
+
+interface IndexPageInterface extends BaseIndexPageInterface
+{
+    public function hasInvoiceLinks(): bool;
+
+    public function hasPlainInvoiceNumbers(): bool;
+}

--- a/tests/Behat/Page/Shop/Order/ShowPageInterface.php
+++ b/tests/Behat/Page/Shop/Order/ShowPageInterface.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace Tests\Sylius\InvoicingPlugin\Behat\Page\Shop\Order;

--- a/tests/Behat/Resources/services.xml
+++ b/tests/Behat/Resources/services.xml
@@ -6,6 +6,15 @@
     </parameters>
 
     <services>
+        <service id="Tests\Sylius\InvoicingPlugin\Behat\Page\Shop\Account\Order\IndexPageInterface"
+                 class="Tests\Sylius\InvoicingPlugin\Behat\Page\Shop\Account\Order\IndexPage"
+                 parent="sylius.behat.page.shop.account.order.index"
+                 public="true"
+        />
+
+        <service id="Tests\Sylius\InvoicingPlugin\Behat\Context\Ui\Shop\AccountContext" public="true">
+            <argument type="service" id="Tests\Sylius\InvoicingPlugin\Behat\Page\Shop\Account\Order\IndexPageInterface" />
+        </service>
         <service id="Tests\Sylius\InvoicingPlugin\Behat\Context\Ui\Admin\ManagingInvoicesContext" public="true">
             <argument type="service" id="Tests\Sylius\InvoicingPlugin\Behat\Page\Admin\Invoice\IndexPageInterface" />
             <argument type="service" id="Tests\Sylius\InvoicingPlugin\Behat\Page\Admin\Invoice\ShowPageInterface" />

--- a/tests/Behat/Resources/suites/customer.yml
+++ b/tests/Behat/Resources/suites/customer.yml
@@ -49,6 +49,7 @@ default:
                 - sylius.behat.context.ui.shop.checkout.complete
                 - sylius.behat.context.ui.shop.currency
 
+                - Tests\Sylius\InvoicingPlugin\Behat\Context\Ui\Shop\AccountContext
                 - Tests\Sylius\InvoicingPlugin\Behat\Context\Ui\Shop\CustomerBrowsingInvoicesContext
 
             filters:


### PR DESCRIPTION
New clickable download buttons on orders grid

<img width="1399" height="519" alt="image" src="https://github.com/user-attachments/assets/4af34220-f904-4fd3-b026-1de8681a6929" />
