### PR TITLE
Update Symfony dependencies to 7.4 along with sylius version bump

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,8 +28,8 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.2", "8.3"]
-                symfony: ["^6.4", "~7.3.0"]
-                sylius: ["~2.0.0", "~2.1.0"]
+                symfony: ["^6.4", "~7.4.0"]
+                sylius: ["~2.1.0", "~2.2.0"]
                 node: ["22.x"]
                 database: ["mysql"]
                 database_version: ["8.4"]
@@ -39,8 +39,8 @@ jobs:
                 include:
                     -
                         php: "8.3"
-                        symfony: "~7.3.0"
-                        sylius: "~2.1.0"
+                        symfony: "~7.4.0"
+                        sylius: "~2.2.0"
                         node: "24.x"
                         database: "mysql"
                         database_version: "8.4"
@@ -49,8 +49,8 @@ jobs:
 
                     -
                         php: "8.3"
-                        symfony: "~7.3.0"
-                        sylius: "~2.1.0"
+                        symfony: "~7.4.0"
+                        sylius: "~2.2.0"
                         node: "24.x"
                         database: "mysql"
                         database_version: "8.4"
@@ -59,8 +59,8 @@ jobs:
 
                     -
                         php: "8.3"
-                        symfony: "~7.3.0"
-                        sylius: "~2.1.0"
+                        symfony: "~7.4.0"
+                        sylius: "~2.2.0"
                         node: "24.x"
                         database: "postgres"
                         database_version: "15.8"

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
         "sylius/grid-bundle": "^1.13",
         "sylius/resource-bundle": "^1.12",
         "sylius/sylius": "^2.0",
-        "symfony/clock": "^6.4 || ^7.1",
-        "symfony/config": "^6.4 || ^7.1",
-        "symfony/console": "^6.4 || ^7.1",
-        "symfony/dependency-injection": "^6.4 || ^7.1",
-        "symfony/form": "^6.4 || ^7.1",
-        "symfony/framework-bundle": "^6.4 || ^7.1",
-        "symfony/http-foundation": "^6.4 || ^7.1",
-        "symfony/http-kernel": "^6.4 || ^7.1",
-        "symfony/messenger": "^6.4 || ^7.1",
-        "symfony/options-resolver": "^6.4 || ^7.1",
-        "symfony/routing": "^6.4 || ^7.1"
+        "symfony/clock": "^6.4 || ^7.3",
+        "symfony/config": "^6.4 || ^7.3",
+        "symfony/console": "^6.4 || ^7.3",
+        "symfony/dependency-injection": "^6.4 || ^7.3",
+        "symfony/form": "^6.4 || ^7.3",
+        "symfony/framework-bundle": "^6.4 || ^7.3",
+        "symfony/http-foundation": "^6.4 || ^7.3",
+        "symfony/http-kernel": "^6.4 || ^7.3",
+        "symfony/messenger": "^6.4 || ^7.3",
+        "symfony/options-resolver": "^6.4 || ^7.3",
+        "symfony/routing": "^6.4 || ^7.3"
     },
     "require-dev": {
         "behat/behat": "^3.14",
@@ -46,12 +46,12 @@
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "sylius-labs/coding-standard": "^4.4",
         "sylius/test-application": "^2.0.0@alpha",
-        "symfony/browser-kit": "^6.4 || ^7.1",
-        "symfony/debug-bundle": "^6.4 || ^7.1",
-        "symfony/dotenv": "^6.4 || ^7.1",
-        "symfony/intl": "^6.4 || ^7.1",
+        "symfony/browser-kit": "^6.4 || ^7.3",
+        "symfony/debug-bundle": "^6.4 || ^7.3",
+        "symfony/dotenv": "^6.4 || ^7.3",
+        "symfony/intl": "^6.4 || ^7.3",
         "symfony/webpack-encore-bundle": "^2.2",
-        "symfony/web-profiler-bundle": "^6.4 || ^7.1"
+        "symfony/web-profiler-bundle": "^6.4 || ^7.3"
     },
     "autoload": {
         "psr-4": {
@@ -89,7 +89,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "~7.2.0"
+            "require": "~7.3.0"
         },
         "branch-alias": {
             "dev-2.0": "2.0-dev"

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
         "sylius/grid-bundle": "^1.13",
         "sylius/resource-bundle": "^1.12",
         "sylius/sylius": "^2.0",
-        "symfony/clock": "^6.4 || ^7.3",
-        "symfony/config": "^6.4 || ^7.3",
-        "symfony/console": "^6.4 || ^7.3",
-        "symfony/dependency-injection": "^6.4 || ^7.3",
-        "symfony/form": "^6.4 || ^7.3",
-        "symfony/framework-bundle": "^6.4 || ^7.3",
-        "symfony/http-foundation": "^6.4 || ^7.3",
-        "symfony/http-kernel": "^6.4 || ^7.3",
-        "symfony/messenger": "^6.4 || ^7.3",
-        "symfony/options-resolver": "^6.4 || ^7.3",
-        "symfony/routing": "^6.4 || ^7.3"
+        "symfony/clock": "^6.4 || ^7.4",
+        "symfony/config": "^6.4 || ^7.4",
+        "symfony/console": "^6.4 || ^7.4",
+        "symfony/dependency-injection": "^6.4 || ^7.4",
+        "symfony/form": "^6.4 || ^7.4",
+        "symfony/framework-bundle": "^6.4 || ^7.4",
+        "symfony/http-foundation": "^6.4 || ^7.4",
+        "symfony/http-kernel": "^6.4 || ^7.4",
+        "symfony/messenger": "^6.4 || ^7.4",
+        "symfony/options-resolver": "^6.4 || ^7.4",
+        "symfony/routing": "^6.4 || ^7.4"
     },
     "require-dev": {
         "behat/behat": "^3.14",
@@ -46,12 +46,12 @@
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "sylius-labs/coding-standard": "^4.4",
         "sylius/test-application": "^2.0.0@alpha",
-        "symfony/browser-kit": "^6.4 || ^7.3",
-        "symfony/debug-bundle": "^6.4 || ^7.3",
-        "symfony/dotenv": "^6.4 || ^7.3",
-        "symfony/intl": "^6.4 || ^7.3",
+        "symfony/browser-kit": "^6.4 || ^7.4",
+        "symfony/debug-bundle": "^6.4 || ^7.4",
+        "symfony/dotenv": "^6.4 || ^7.4",
+        "symfony/intl": "^6.4 || ^7.4",
         "symfony/webpack-encore-bundle": "^2.2",
-        "symfony/web-profiler-bundle": "^6.4 || ^7.3"
+        "symfony/web-profiler-bundle": "^6.4 || ^7.4"
     },
     "autoload": {
         "psr-4": {
@@ -89,7 +89,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "~7.3.0"
+            "require": "~7.4.0"
         },
         "branch-alias": {
             "dev-2.0": "2.0-dev"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,7 @@ parameters:
     ignoreErrors:
         - identifier: missingType.generics
         - identifier: missingType.iterableValue
+        - '/Call to method \w+\(\) on an unknown class Symfony\\Component\\Config\\Definition\\Builder\\NodeBuilder/'
         - '/Method Sylius\\InvoicingPlugin\\Entity\\\w+::id\(\) has no return type specified\./'
         - '/Method Sylius\\InvoicingPlugin\\Entity\\\w+::getId\(\) has no return type specified\./'
         - '/Method Sylius\\InvoicingPlugin\\[a-zA-Z\\]+::getFlashBag\(\) should return Symfony\\Component\\HttpFoundation\\Session\\Flash\\FlashBagInterface but returns Symfony\\Component\\HttpFoundation\\Session\\SessionBagInterface\./'


### PR DESCRIPTION
## Summary
- Updates all Symfony component version constraints from `^7.1` to `^7.4`
- Updates Symfony Flex requirement from `~7.2.0` to `~7.4.0`
