### PR TITLE
Feature/add ability to resend automatically failed generated pdf

### DIFF
--- a/config/doctrine/Invoice.orm.xml
+++ b/config/doctrine/Invoice.orm.xml
@@ -10,6 +10,7 @@
         <field name="localeCode" column="locale_code" />
         <field name="total" column="total" type="integer" />
         <field name="paymentState" column="payment_state" />
+        <field name="pdfSent" column="pdf_sent" type="boolean" />
 
         <one-to-one field="billingData" target-entity="Sylius\InvoicingPlugin\Entity\BillingDataInterface">
             <cascade>

--- a/config/services.xml
+++ b/config/services.xml
@@ -23,13 +23,25 @@
     <parameters>
         <parameter key="sylius_invoicing.default_logo_file">@SyliusInvoicingPlugin/assets/sylius-logo.png</parameter>
         <parameter key="sylius_invoicing.template.logo_file">%env(default:sylius_invoicing.default_logo_file:resolve:SYLIUS_INVOICING_LOGO_FILE)%</parameter>
+        <parameter key="sylius_invoicing.email.retry_max_attempts">3</parameter>
+        <parameter key="sylius_invoicing.email.retry_delay_ms">60000</parameter>
     </parameters>
 
     <services>
+        <service id="sylius_invoicing.email.invoice_email_retry_scheduler" class="Sylius\InvoicingPlugin\Email\InvoiceEmailRetryScheduler">
+            <argument type="service" id="sylius.command_bus" />
+            <argument>%sylius_invoicing.email.retry_max_attempts%</argument>
+            <argument>%sylius_invoicing.email.retry_delay_ms%</argument>
+            <argument type="service" id="logger" on-invalid="null" />
+        </service>
+        <service id="Sylius\InvoicingPlugin\Email\InvoiceEmailRetrySchedulerInterface" alias="sylius_invoicing.email.invoice_email_retry_scheduler" />
+
         <service id="sylius_invoicing.email.invoice_email_sender" class="Sylius\InvoicingPlugin\Email\InvoiceEmailSender">
             <argument type="service" id="sylius.email_sender" />
             <argument type="service" id="sylius_invoicing.provider.invoice_file" />
             <argument>%sylius_invoicing.pdf_generator.enabled%</argument>
+            <argument type="service" id="logger" on-invalid="null" />
+            <argument type="service" id="sylius_invoicing.email.invoice_email_retry_scheduler" on-invalid="null" />
         </service>
         <service id="Sylius\InvoicingPlugin\Email\InvoiceEmailSenderInterface" alias="sylius_invoicing.email.invoice_email_sender" />
 

--- a/config/services/cli.xml
+++ b/config/services/cli.xml
@@ -24,5 +24,11 @@
             <argument type="service" id="sylius.repository.order" />
             <tag name="console.command" />
         </service>
+        <service id="sylius_invoicing.cli.retry_failed_invoices" class="Sylius\InvoicingPlugin\Cli\RetryFailedInvoicesCommand">
+            <argument type="service" id="sylius_invoicing.repository.invoice" />
+            <argument type="service" id="sylius.command_bus" />
+            <argument type="service" id="logger" />
+            <tag name="console.command" />
+        </service>
     </services>
 </container>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -22,3 +22,4 @@ parameters:
         - '/Method Sylius\\InvoicingPlugin\\Security\\Voter\\InvoiceVoter::supports\(\) has parameter \$attribute with no typehint specified./'
         - '/Method Sylius\\InvoicingPlugin\\Security\\Voter\\InvoiceVoter::supports\(\) has parameter \$subject with no typehint specified./'
         - '/expects string, string\|null given\.$/'
+        - '/Method Sylius\\Component\\Mailer\\Sender\\SenderInterface::send\(\) invoked with 7 parameters, 2-5 required\./'

--- a/src/Cli/RetryFailedInvoicesCommand.php
+++ b/src/Cli/RetryFailedInvoicesCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\InvoicingPlugin\Cli;
+
+use Psr\Log\LoggerInterface;
+use Sylius\InvoicingPlugin\Command\SendInvoiceEmail;
+use Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepositoryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+#[AsCommand(
+    name: 'sylius-invoicing:retry-failed-invoices',
+    description: 'Retries sending invoice emails for invoices with missing PDF attachments.',
+)]
+final class RetryFailedInvoicesCommand extends Command
+{
+    public function __construct(
+        private readonly InvoiceRepositoryInterface $invoiceRepository,
+        private readonly MessageBusInterface $commandBus,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $failedInvoices = $this->invoiceRepository->findUnsent();
+
+        if ([] === $failedInvoices) {
+            $output->writeln('No failed invoices found to retry.');
+
+            return Command::SUCCESS;
+        }
+
+        $dispatched = 0;
+
+        foreach ($failedInvoices as $invoice) {
+            $orderNumber = $invoice->order()->getNumber();
+
+            if (null === $orderNumber) {
+                continue;
+            }
+
+            try {
+                $this->commandBus->dispatch(new SendInvoiceEmail($orderNumber));
+            } catch (ExceptionInterface $e) {
+                $this->logger->error(
+                    sprintf(
+                        'Failed to dispatch invoice resend command for order %s: %s',
+                        $orderNumber,
+                        $e->getMessage(),
+                    ),
+                    ['exception' => $e],
+                );
+            }
+            ++$dispatched;
+        }
+
+        $output->writeln(sprintf('Dispatched %d invoice resend command(s).', $dispatched));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/SendInvoiceEmail.php
+++ b/src/Command/SendInvoiceEmail.php
@@ -13,14 +13,21 @@ declare(strict_types=1);
 
 namespace Sylius\InvoicingPlugin\Command;
 
-final class SendInvoiceEmail
+final readonly class SendInvoiceEmail
 {
-    public function __construct(private readonly string $orderNumber)
-    {
+    public function __construct(
+        private string $orderNumber,
+        private int $attempt = 0,
+    ) {
     }
 
     public function orderNumber(): string
     {
         return $this->orderNumber;
+    }
+
+    public function attempt(): int
+    {
+        return $this->attempt;
     }
 }

--- a/src/CommandHandler/SendInvoiceEmailHandler.php
+++ b/src/CommandHandler/SendInvoiceEmailHandler.php
@@ -20,12 +20,12 @@ use Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepositoryInterface;
 use Sylius\InvoicingPlugin\Email\InvoiceEmailSenderInterface;
 use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
 
-final class SendInvoiceEmailHandler
+final readonly class SendInvoiceEmailHandler
 {
     public function __construct(
-        private readonly InvoiceRepositoryInterface $invoiceRepository,
-        private readonly OrderRepositoryInterface $orderRepository,
-        private readonly InvoiceEmailSenderInterface $emailSender,
+        private InvoiceRepositoryInterface $invoiceRepository,
+        private OrderRepositoryInterface $orderRepository,
+        private InvoiceEmailSenderInterface $emailSender,
     ) {
     }
 
@@ -48,6 +48,15 @@ final class SendInvoiceEmailHandler
             return;
         }
 
-        $this->emailSender->sendInvoiceEmail($invoice, $customer->getEmail());
+        $customerEmail = $customer->getEmail();
+        if (null === $customerEmail) {
+            return;
+        }
+
+        $this->emailSender->sendInvoiceEmail($invoice, $customerEmail, $command->attempt());
+
+        if ($invoice->isPdfSent()) {
+            $this->invoiceRepository->add($invoice);
+        }
     }
 }

--- a/src/Doctrine/ORM/InvoiceRepository.php
+++ b/src/Doctrine/ORM/InvoiceRepository.php
@@ -43,4 +43,19 @@ class InvoiceRepository extends EntityRepository implements InvoiceRepositoryInt
 
         return $invoices;
     }
+
+    public function findUnsent(): array
+    {
+        $invoices = $this
+            ->createQueryBuilder('invoice')
+            ->where('invoice.pdfSent = :pdfSent')
+            ->setParameter('pdfSent', false)
+            ->getQuery()
+            ->getResult()
+        ;
+
+        Assert::isArray($invoices);
+
+        return $invoices;
+    }
 }

--- a/src/Doctrine/ORM/InvoiceRepositoryInterface.php
+++ b/src/Doctrine/ORM/InvoiceRepositoryInterface.php
@@ -22,4 +22,9 @@ interface InvoiceRepositoryInterface extends RepositoryInterface
     public function findOneByOrder(OrderInterface $order): ?InvoiceInterface;
 
     public function findByOrderNumber(string $orderNumber): array;
+
+    /**
+     * @return array<InvoiceInterface>
+     */
+    public function findUnsent(): array;
 }

--- a/src/Email/InvoiceEmailRetryScheduler.php
+++ b/src/Email/InvoiceEmailRetryScheduler.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\InvoicingPlugin\Email;
+
+use Psr\Log\LoggerInterface;
+use Sylius\InvoicingPlugin\Command\SendInvoiceEmail;
+use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+
+final class InvoiceEmailRetryScheduler implements InvoiceEmailRetrySchedulerInterface
+{
+    public function __construct(
+        private readonly MessageBusInterface $commandBus,
+        private readonly int $maxAttempts,
+        private readonly int $retryDelayMilliseconds,
+        private readonly ?LoggerInterface $logger = null,
+    ) {
+    }
+
+    public function scheduleRetry(InvoiceInterface $invoice, string $customerEmail, int $attempt): void
+    {
+        if ($attempt >= $this->maxAttempts) {
+            $this->logger?->warning(
+                sprintf(
+                    'Invoice email retry aborted for invoice "%s" (%s) after %d attempts.',
+                    $invoice->number(),
+                    $invoice->id(),
+                    $attempt,
+                ),
+                ['customerEmail' => $customerEmail],
+            );
+
+            return;
+        }
+
+        $orderNumber = $invoice->order()->getNumber();
+        if (null === $orderNumber) {
+            $this->logger?->warning(
+                sprintf(
+                    'Invoice email retry skipped because order number is missing for invoice "%s" (%s).',
+                    $invoice->number(),
+                    $invoice->id(),
+                ),
+                ['customerEmail' => $customerEmail],
+            );
+
+            return;
+        }
+
+        $nextAttempt = $attempt + 1;
+        $message = new SendInvoiceEmail($orderNumber, $nextAttempt);
+        $envelope = new Envelope($message, [new DelayStamp($this->retryDelayMilliseconds)]);
+
+        try {
+            $this->commandBus->dispatch($envelope);
+        } catch (ExceptionInterface $e) {
+            $this->logger?->error($e->getMessage());
+        }
+
+        $this->logger?->info(
+            sprintf(
+                'Scheduled invoice email retry #%d for invoice "%s" (%s) to "%s".',
+                $nextAttempt,
+                $invoice->number(),
+                $invoice->id(),
+                $customerEmail,
+            ),
+        );
+    }
+}

--- a/src/Email/InvoiceEmailRetrySchedulerInterface.php
+++ b/src/Email/InvoiceEmailRetrySchedulerInterface.php
@@ -15,7 +15,7 @@ namespace Sylius\InvoicingPlugin\Email;
 
 use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
 
-interface InvoiceEmailSenderInterface
+interface InvoiceEmailRetrySchedulerInterface
 {
-    public function sendInvoiceEmail(InvoiceInterface $invoice, string $customerEmail, int $attempt = 0): void;
+    public function scheduleRetry(InvoiceInterface $invoice, string $customerEmail, int $attempt): void;
 }

--- a/src/Email/InvoiceEmailSender.php
+++ b/src/Email/InvoiceEmailSender.php
@@ -13,8 +13,10 @@ declare(strict_types=1);
 
 namespace Sylius\InvoicingPlugin\Email;
 
+use Psr\Log\LoggerInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
+use Sylius\InvoicingPlugin\Exception\InvoiceFileGenerationFailedException;
 use Sylius\InvoicingPlugin\Provider\InvoiceFileProviderInterface;
 use Webmozart\Assert\Assert;
 
@@ -24,21 +26,68 @@ final class InvoiceEmailSender implements InvoiceEmailSenderInterface
         private readonly SenderInterface $emailSender,
         private readonly InvoiceFileProviderInterface $invoiceFileProvider,
         private readonly bool $hasEnabledPdfFileGenerator = true,
+        private readonly ?LoggerInterface $logger = null,
+        private readonly ?InvoiceEmailRetrySchedulerInterface $retryScheduler = null,
     ) {
     }
 
-    public function sendInvoiceEmail(InvoiceInterface $invoice, string $customerEmail): void
+    public function sendInvoiceEmail(InvoiceInterface $invoice, string $customerEmail, int $attempt = 0): void
     {
         if (!$this->hasEnabledPdfFileGenerator) {
-            $this->emailSender->send(Emails::INVOICE_GENERATED, [$customerEmail], ['invoice' => $invoice]);
+            $this->emailSender->send(
+                Emails::INVOICE_GENERATED,
+                [$customerEmail],
+                ['invoice' => $invoice],
+                [],
+                [],
+                [],
+                [],
+            );
 
             return;
         }
 
-        $invoicePdf = $this->invoiceFileProvider->provide($invoice);
-        $invoicePdfPath = $invoicePdf->fullPath();
-        Assert::notNull($invoicePdfPath);
+        try {
+            $invoicePdf = $this->invoiceFileProvider->provide($invoice);
+            $invoicePdfPath = $invoicePdf->fullPath();
+            Assert::notNull($invoicePdfPath);
 
-        $this->emailSender->send(Emails::INVOICE_GENERATED, [$customerEmail], ['invoice' => $invoice], [$invoicePdfPath]);
+            if (!is_file($invoicePdfPath) || !is_readable($invoicePdfPath)) {
+                throw InvoiceFileGenerationFailedException::forInvoice(
+                    $invoice,
+                    new \RuntimeException(sprintf('Invoice PDF file "%s" is not readable.', $invoicePdfPath)),
+                );
+            }
+
+            $this->emailSender->send(
+                Emails::INVOICE_GENERATED,
+                [$customerEmail],
+                ['invoice' => $invoice],
+                [$invoicePdfPath],
+                [],
+                [],
+                [],
+            );
+
+            $invoice->setPdfSent(true);
+        } catch (InvoiceFileGenerationFailedException $exception) {
+            if (null !== $this->logger) {
+                $this->logger->error(
+                    sprintf(
+                        'Invoice PDF for invoice "%s" (%s) could not be generated. Email to "%s" will not be sent.',
+                        $invoice->number(),
+                        $invoice->id(),
+                        $customerEmail,
+                    ),
+                    ['exception' => $exception],
+                );
+            }
+
+            if (null !== $this->retryScheduler) {
+                $this->retryScheduler->scheduleRetry($invoice, $customerEmail, $attempt);
+            }
+
+            $invoice->setPdfSent(false);
+        }
     }
 }

--- a/src/Entity/Invoice.php
+++ b/src/Entity/Invoice.php
@@ -36,6 +36,7 @@ class Invoice implements InvoiceInterface
         protected ChannelInterface $channel,
         protected string $paymentState,
         protected InvoiceShopBillingDataInterface $shopBillingData,
+        protected bool $pdfSent = false,
     ) {
         $this->issuedAt = clone $issuedAt;
 
@@ -142,5 +143,15 @@ class Invoice implements InvoiceInterface
     public function paymentState(): string
     {
         return $this->paymentState;
+    }
+
+    public function isPdfSent(): bool
+    {
+        return $this->pdfSent;
+    }
+
+    public function setPdfSent(bool $pdfSent): void
+    {
+        $this->pdfSent = $pdfSent;
     }
 }

--- a/src/Entity/InvoiceInterface.php
+++ b/src/Entity/InvoiceInterface.php
@@ -53,4 +53,8 @@ interface InvoiceInterface extends ResourceInterface
     public function shopBillingData(): InvoiceShopBillingDataInterface;
 
     public function paymentState(): string;
+
+    public function isPdfSent(): bool;
+
+    public function setPdfSent(bool $pdfSent): void;
 }

--- a/src/Exception/InvoiceFileGenerationFailedException.php
+++ b/src/Exception/InvoiceFileGenerationFailedException.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Sylius\InvoicingPlugin\Exception;
+
+use function sprintf;
+use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
+
+final class InvoiceFileGenerationFailedException extends \RuntimeException
+{
+    public static function occur(): self
+    {
+        return new self('Invoice file cannot be generated.');
+    }
+
+    public static function forInvoice(InvoiceInterface $invoice, \Throwable $previous): self
+    {
+        return new self(
+            sprintf(
+                'Invoice file for invoice "%s" (%s) cannot be generated.',
+                $invoice->number(),
+                $invoice->id(),
+            ),
+            0,
+            $previous,
+        );
+    }
+}

--- a/src/Migrations/Version20251016094233.php
+++ b/src/Migrations/Version20251016094233.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Sylius\InvoicingPlugin\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractPostgreSQLMigration;
+
 
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20251016094233 extends AbstractMigration
+final class Version20251016094233 extends AbstractPostgreSQLMigration
 {
     public function getDescription(): string
     {

--- a/src/Migrations/Version20251016094233.php
+++ b/src/Migrations/Version20251016094233.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\InvoicingPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251016094233 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add pdf_sent column to sylius_invoicing_plugin_invoice table (PostgreSql)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_invoicing_plugin_invoice ADD pdf_sent BOOLEAN NOT NULL DEFAULT FALSE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_invoicing_plugin_invoice DROP pdf_sent');
+    }
+}

--- a/src/Migrations/Version20251016095237.php
+++ b/src/Migrations/Version20251016095237.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Sylius\InvoicingPlugin\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
-use Doctrine\Migrations\AbstractMigration;
+use Sylius\Bundle\CoreBundle\Doctrine\Migrations\AbstractMigration;
+
 
 /**
  * Auto-generated Migration: Please modify to your needs!

--- a/src/Migrations/Version20251016095237.php
+++ b/src/Migrations/Version20251016095237.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sylius\InvoicingPlugin\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20251016095237 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add pdf_sent column to sylius_invoicing_plugin_invoice table (MYSQL)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_invoicing_plugin_invoice ADD pdf_sent TINYINT(1) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE sylius_invoicing_plugin_invoice DROP pdf_sent');
+    }
+}

--- a/src/Provider/InvoiceFileProvider.php
+++ b/src/Provider/InvoiceFileProvider.php
@@ -16,19 +16,20 @@ namespace Sylius\InvoicingPlugin\Provider;
 use Gaufrette\Exception\FileNotFound;
 use Gaufrette\FilesystemInterface;
 use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
+use Sylius\InvoicingPlugin\Exception\InvoiceFileGenerationFailedException;
 use Sylius\InvoicingPlugin\Generator\InvoiceFileNameGeneratorInterface;
 use Sylius\InvoicingPlugin\Generator\InvoicePdfFileGeneratorInterface;
 use Sylius\InvoicingPlugin\Manager\InvoiceFileManagerInterface;
 use Sylius\InvoicingPlugin\Model\InvoicePdf;
 
-final class InvoiceFileProvider implements InvoiceFileProviderInterface
+final readonly class InvoiceFileProvider implements InvoiceFileProviderInterface
 {
     public function __construct(
-        private readonly InvoiceFileNameGeneratorInterface $invoiceFileNameGenerator,
-        private readonly FilesystemInterface $filesystem,
-        private readonly InvoicePdfFileGeneratorInterface $invoicePdfFileGenerator,
-        private readonly InvoiceFileManagerInterface $invoiceFileManager,
-        private readonly string $invoicesDirectory,
+        private InvoiceFileNameGeneratorInterface $invoiceFileNameGenerator,
+        private FilesystemInterface $filesystem,
+        private InvoicePdfFileGeneratorInterface $invoicePdfFileGenerator,
+        private InvoiceFileManagerInterface $invoiceFileManager,
+        private string $invoicesDirectory,
     ) {
     }
 
@@ -40,8 +41,12 @@ final class InvoiceFileProvider implements InvoiceFileProviderInterface
             $invoiceFile = $this->filesystem->get($invoiceFileName);
             $invoicePdf = new InvoicePdf($invoiceFileName, $invoiceFile->getContent());
         } catch (FileNotFound) {
-            $invoicePdf = $this->invoicePdfFileGenerator->generate($invoice);
-            $this->invoiceFileManager->save($invoicePdf);
+            try {
+                $invoicePdf = $this->invoicePdfFileGenerator->generate($invoice);
+                $this->invoiceFileManager->save($invoicePdf);
+            } catch (\Throwable $exception) {
+                throw InvoiceFileGenerationFailedException::forInvoice($invoice, $exception);
+            }
         }
 
         $invoicePdf->setFullPath($this->invoicesDirectory . '/' . $invoiceFileName);

--- a/tests/Unit/CommandHandler/SendInvoiceEmailHandlerTest.php
+++ b/tests/Unit/CommandHandler/SendInvoiceEmailHandlerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\InvoicingPlugin\Unit\CommandHandler;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -27,11 +28,21 @@ use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
 
 final class SendInvoiceEmailHandlerTest extends TestCase
 {
+    private const ORDER_NUMBER = '0000001';
+
+    private const CUSTOMER_EMAIL = 'customer@example.com';
+
     private InvoiceRepositoryInterface&MockObject $invoiceRepository;
 
     private MockObject&OrderRepositoryInterface $orderRepository;
 
     private InvoiceEmailSenderInterface&MockObject $emailSender;
+
+    private MockObject&OrderInterface $order;
+
+    private CustomerInterface&MockObject $customer;
+
+    private InvoiceInterface&MockObject $invoice;
 
     private SendInvoiceEmailHandler $handler;
 
@@ -41,6 +52,9 @@ final class SendInvoiceEmailHandlerTest extends TestCase
         $this->invoiceRepository = $this->createMock(InvoiceRepositoryInterface::class);
         $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
         $this->emailSender = $this->createMock(InvoiceEmailSenderInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+        $this->customer = $this->createMock(CustomerInterface::class);
+        $this->invoice = $this->createMock(InvoiceInterface::class);
 
         $this->handler = new SendInvoiceEmailHandler(
             $this->invoiceRepository,
@@ -50,116 +64,215 @@ final class SendInvoiceEmailHandlerTest extends TestCase
     }
 
     #[Test]
-    public function it_requests_an_email_with_an_invoice_to_be_sent(): void
+    #[DataProvider('attemptProvider')]
+    public function it_sends_invoice_email_with_different_attempts(int $attempt): void
     {
-        $invoice = $this->createMock(InvoiceInterface::class);
-        $order = $this->createMock(OrderInterface::class);
-        $customer = $this->createMock(CustomerInterface::class);
+        $this->expectOrderFound();
+        $this->expectCustomerFound();
+        $this->expectInvoiceFound();
 
-        $this->orderRepository
+        $this->invoice
             ->expects(self::once())
-            ->method('findOneByNumber')
-            ->with('0000001')
-            ->willReturn($order);
-
-        $order
-            ->expects(self::once())
-            ->method('getCustomer')
-            ->willReturn($customer);
-
-        $customer
-            ->expects(self::once())
-            ->method('getEmail')
-            ->willReturn('shop@example.com');
+            ->method('isPdfSent')
+            ->willReturn(false);
 
         $this->invoiceRepository
-            ->expects(self::once())
-            ->method('findOneByOrder')
-            ->with($order)
-            ->willReturn($invoice);
+            ->expects(self::never())
+            ->method('add');
 
         $this->emailSender
             ->expects(self::once())
             ->method('sendInvoiceEmail')
-            ->with($invoice, 'shop@example.com');
+            ->with($this->invoice, self::CUSTOMER_EMAIL, $attempt);
 
-        ($this->handler)(new SendInvoiceEmail('0000001'));
+        ($this->handler)(new SendInvoiceEmail(self::ORDER_NUMBER, $attempt));
     }
 
     #[Test]
-    public function it_does_not_request_an_email_to_be_sent_if_order_was_not_found(): void
+    #[DataProvider('pdfSentStatusProvider')]
+    public function it_persists_invoice_only_when_pdf_was_sent(bool $pdfSent, bool $shouldPersist): void
+    {
+        $this->expectOrderFound();
+        $this->expectCustomerFound();
+        $this->expectInvoiceFound();
+
+        $this->invoice
+            ->expects(self::once())
+            ->method('isPdfSent')
+            ->willReturn($pdfSent);
+
+        if ($shouldPersist) {
+            $this->invoiceRepository
+                ->expects(self::once())
+                ->method('add')
+                ->with($this->invoice);
+        } else {
+            $this->invoiceRepository
+                ->expects(self::never())
+                ->method('add');
+        }
+
+        $this->emailSender
+            ->expects(self::once())
+            ->method('sendInvoiceEmail')
+            ->with($this->invoice, self::CUSTOMER_EMAIL, 0);
+
+        ($this->handler)(new SendInvoiceEmail(self::ORDER_NUMBER));
+    }
+
+    #[Test]
+    public function it_does_not_send_email_when_order_not_found(): void
     {
         $this->orderRepository
             ->expects(self::once())
             ->method('findOneByNumber')
-            ->with('0000001')
+            ->with(self::ORDER_NUMBER)
             ->willReturn(null);
 
         $this->invoiceRepository
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('findOneByOrder');
 
         $this->emailSender
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('sendInvoiceEmail');
 
-        ($this->handler)(new SendInvoiceEmail('0000001'));
+        $this->invoiceRepository
+            ->expects(self::never())
+            ->method('add');
+
+        ($this->handler)(new SendInvoiceEmail(self::ORDER_NUMBER));
     }
 
     #[Test]
-    public function it_does_not_request_an_email_to_be_sent_if_customer_was_not_found(): void
+    public function it_does_not_send_email_when_customer_not_found(): void
     {
-        $order = $this->createMock(OrderInterface::class);
+        $this->expectOrderFound();
 
-        $this->orderRepository
-            ->expects(self::once())
-            ->method('findOneByNumber')
-            ->with('0000001')
-            ->willReturn($order);
-
-        $order
+        $this->order
             ->expects(self::once())
             ->method('getCustomer')
             ->willReturn(null);
 
         $this->invoiceRepository
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('findOneByOrder');
 
         $this->emailSender
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('sendInvoiceEmail');
 
-        ($this->handler)(new SendInvoiceEmail('0000001'));
+        $this->invoiceRepository
+            ->expects(self::never())
+            ->method('add');
+
+        ($this->handler)(new SendInvoiceEmail(self::ORDER_NUMBER));
     }
 
     #[Test]
-    public function it_does_not_request_an_email_to_be_sent_if_invoice_was_not_found(): void
+    public function it_does_not_send_email_when_invoice_not_found(): void
     {
-        $order = $this->createMock(OrderInterface::class);
-        $customer = $this->createMock(CustomerInterface::class);
+        $this->expectOrderFound();
 
-        $this->orderRepository
-            ->expects(self::once())
-            ->method('findOneByNumber')
-            ->with('0000001')
-            ->willReturn($order);
-
-        $order
+        $this->order
             ->expects(self::once())
             ->method('getCustomer')
-            ->willReturn($customer);
+            ->willReturn($this->customer);
 
         $this->invoiceRepository
             ->expects(self::once())
             ->method('findOneByOrder')
-            ->with($order)
+            ->with($this->order)
             ->willReturn(null);
 
         $this->emailSender
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('sendInvoiceEmail');
 
-        ($this->handler)(new SendInvoiceEmail('0000001'));
+        $this->invoiceRepository
+            ->expects(self::never())
+            ->method('add');
+
+        ($this->handler)(new SendInvoiceEmail(self::ORDER_NUMBER));
+    }
+
+    #[Test]
+    public function it_does_not_send_email_when_customer_email_is_null(): void
+    {
+        $this->expectOrderFound();
+
+        $this->order
+            ->expects(self::once())
+            ->method('getCustomer')
+            ->willReturn($this->customer);
+
+        $this->customer
+            ->expects(self::once())
+            ->method('getEmail')
+            ->willReturn(null);
+
+        $this->invoiceRepository
+            ->expects(self::once())
+            ->method('findOneByOrder')
+            ->with($this->order)
+            ->willReturn($this->invoice);
+
+        $this->emailSender
+            ->expects(self::never())
+            ->method('sendInvoiceEmail');
+
+        $this->invoiceRepository
+            ->expects(self::never())
+            ->method('add');
+
+        ($this->handler)(new SendInvoiceEmail(self::ORDER_NUMBER));
+    }
+
+    public static function attemptProvider(): array
+    {
+        return [
+            'first attempt' => [0],
+            'second attempt' => [1],
+            'third attempt' => [2],
+        ];
+    }
+
+    public static function pdfSentStatusProvider(): array
+    {
+        return [
+            'pdf not sent' => [false, false],
+            'pdf sent successfully' => [true, true],
+        ];
+    }
+
+    private function expectOrderFound(): void
+    {
+        $this->orderRepository
+            ->expects(self::once())
+            ->method('findOneByNumber')
+            ->with(self::ORDER_NUMBER)
+            ->willReturn($this->order);
+    }
+
+    private function expectCustomerFound(): void
+    {
+        $this->order
+            ->expects(self::once())
+            ->method('getCustomer')
+            ->willReturn($this->customer);
+
+        $this->customer
+            ->expects(self::once())
+            ->method('getEmail')
+            ->willReturn(self::CUSTOMER_EMAIL);
+    }
+
+    private function expectInvoiceFound(): void
+    {
+        $this->invoiceRepository
+            ->expects(self::once())
+            ->method('findOneByOrder')
+            ->with($this->order)
+            ->willReturn($this->invoice);
     }
 }

--- a/tests/Unit/Email/InvoiceEmailRetrySchedulerTest.php
+++ b/tests/Unit/Email/InvoiceEmailRetrySchedulerTest.php
@@ -1,0 +1,237 @@
+<?php
+
+/*
+ * This file is part of the Sylius package.
+ *
+ * (c) Sylius Sp. z o.o.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Sylius\InvoicingPlugin\Unit\Email;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\InvoicingPlugin\Command\SendInvoiceEmail;
+use Sylius\InvoicingPlugin\Email\InvoiceEmailRetryScheduler;
+use Sylius\InvoicingPlugin\Email\InvoiceEmailRetrySchedulerInterface;
+use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Exception\ExceptionInterface;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\DelayStamp;
+
+final class InvoiceEmailRetrySchedulerTest extends TestCase
+{
+    private MessageBusInterface&MockObject $commandBus;
+
+    private LoggerInterface&MockObject $logger;
+
+    private InvoiceInterface&MockObject $invoice;
+
+    private MockObject&OrderInterface $order;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->commandBus = $this->createMock(MessageBusInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->invoice = $this->createMock(InvoiceInterface::class);
+        $this->order = $this->createMock(OrderInterface::class);
+
+        $this->invoice
+            ->method('order')
+            ->willReturn($this->order);
+
+        $this->invoice
+            ->method('number')
+            ->willReturn('2024/11/0001');
+
+        $this->invoice
+            ->method('id')
+            ->willReturn('INV-0001');
+    }
+
+    #[Test]
+    public function it_implements_invoice_email_retry_scheduler_interface(): void
+    {
+        $scheduler = new InvoiceEmailRetryScheduler($this->commandBus, 3, 60000);
+
+        self::assertInstanceOf(InvoiceEmailRetrySchedulerInterface::class, $scheduler);
+    }
+
+    #[Test]
+    #[DataProvider('retryAttemptProvider')]
+    public function it_schedules_retry_with_correct_attempt_number_and_delay(
+        int $currentAttempt,
+        int $expectedNextAttempt,
+        int $retryDelay,
+    ): void {
+        $scheduler = new InvoiceEmailRetryScheduler($this->commandBus, 3, $retryDelay, $this->logger);
+
+        $this->order
+            ->method('getNumber')
+            ->willReturn('0000001');
+
+        $this->commandBus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->with(self::callback(function (Envelope $envelope) use ($expectedNextAttempt, $retryDelay) {
+                $message = $envelope->getMessage();
+                $stamps = $envelope->all(DelayStamp::class);
+
+                return $message instanceof SendInvoiceEmail &&
+                    $message->orderNumber() === '0000001' &&
+                    $message->attempt() === $expectedNextAttempt &&
+                    count($stamps) === 1 &&
+                    $stamps[0]->getDelay() === $retryDelay;
+            }))
+            ->willReturn(new Envelope(new SendInvoiceEmail('0000001', $expectedNextAttempt)));
+
+        $this->logger
+            ->expects(self::once())
+            ->method('info')
+            ->with(
+                sprintf(
+                    'Scheduled invoice email retry #%d for invoice "2024/11/0001" (INV-0001) to "customer@example.com".',
+                    $expectedNextAttempt,
+                ),
+            );
+
+        $scheduler->scheduleRetry($this->invoice, 'customer@example.com', $currentAttempt);
+    }
+
+    #[Test]
+    #[DataProvider('abortScenarioProvider')]
+    public function it_aborts_retry_when_max_attempts_reached(
+        int $attempt,
+        string $orderNumber,
+        string $expectedWarningMessage,
+    ): void {
+        $scheduler = new InvoiceEmailRetryScheduler($this->commandBus, 3, 60000, $this->logger);
+
+        $this->order
+            ->method('getNumber')
+            ->willReturn($orderNumber);
+
+        $this->commandBus
+            ->expects(self::never())
+            ->method('dispatch');
+
+        $this->logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                $expectedWarningMessage,
+                ['customerEmail' => 'customer@example.com'],
+            );
+
+        $scheduler->scheduleRetry($this->invoice, 'customer@example.com', $attempt);
+    }
+
+    #[Test]
+    public function it_skips_retry_when_order_number_is_missing(): void
+    {
+        $scheduler = new InvoiceEmailRetryScheduler($this->commandBus, 3, 60000, $this->logger);
+
+        $this->order
+            ->method('getNumber')
+            ->willReturn(null);
+
+        $this->commandBus
+            ->expects(self::never())
+            ->method('dispatch');
+
+        $this->logger
+            ->expects(self::once())
+            ->method('warning')
+            ->with(
+                'Invoice email retry skipped because order number is missing for invoice "2024/11/0001" (INV-0001).',
+                ['customerEmail' => 'customer@example.com'],
+            );
+
+        $scheduler->scheduleRetry($this->invoice, 'customer@example.com', 0);
+    }
+
+    #[Test]
+    public function it_logs_error_when_dispatch_fails(): void
+    {
+        $scheduler = new InvoiceEmailRetryScheduler($this->commandBus, 3, 60000, $this->logger);
+
+        $this->order
+            ->method('getNumber')
+            ->willReturn('0000001');
+
+        $exception = new class('Transport failed') extends \Exception implements ExceptionInterface {
+        };
+
+        $this->commandBus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->willThrowException($exception);
+
+        $this->logger
+            ->expects(self::once())
+            ->method('error')
+            ->with('Transport failed');
+
+        $this->logger
+            ->expects(self::once())
+            ->method('info')
+            ->with(
+                'Scheduled invoice email retry #1 for invoice "2024/11/0001" (INV-0001) to "customer@example.com".',
+            );
+
+        $scheduler->scheduleRetry($this->invoice, 'customer@example.com', 0);
+    }
+
+    #[Test]
+    public function it_works_without_logger(): void
+    {
+        $scheduler = new InvoiceEmailRetryScheduler($this->commandBus, 3, 60000);
+
+        $this->order
+            ->method('getNumber')
+            ->willReturn('0000001');
+
+        $this->commandBus
+            ->expects(self::once())
+            ->method('dispatch')
+            ->willReturn(new Envelope(new SendInvoiceEmail('0000001', 1)));
+
+        $scheduler->scheduleRetry($this->invoice, 'customer@example.com', 0);
+    }
+
+    public static function retryAttemptProvider(): array
+    {
+        return [
+            'first attempt' => [0, 1, 60000],
+            'second attempt' => [1, 2, 60000],
+            'third attempt' => [2, 3, 60000],
+            'custom delay' => [0, 1, 120000],
+        ];
+    }
+
+    public static function abortScenarioProvider(): array
+    {
+        return [
+            'max attempts reached' => [
+                3,
+                '0000001',
+                'Invoice email retry aborted for invoice "2024/11/0001" (INV-0001) after 3 attempts.',
+            ],
+            'attempts exceeded' => [
+                5,
+                '0000001',
+                'Invoice email retry aborted for invoice "2024/11/0001" (INV-0001) after 5 attempts.',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/Email/InvoiceEmailSenderTest.php
+++ b/tests/Unit/Email/InvoiceEmailSenderTest.php
@@ -13,28 +13,60 @@ declare(strict_types=1);
 
 namespace Tests\Sylius\InvoicingPlugin\Unit\Email;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use Sylius\Component\Mailer\Sender\SenderInterface;
 use Sylius\InvoicingPlugin\Email\Emails;
+use Sylius\InvoicingPlugin\Email\InvoiceEmailRetrySchedulerInterface;
 use Sylius\InvoicingPlugin\Email\InvoiceEmailSender;
 use Sylius\InvoicingPlugin\Email\InvoiceEmailSenderInterface;
 use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
+use Sylius\InvoicingPlugin\Exception\InvoiceFileGenerationFailedException;
 use Sylius\InvoicingPlugin\Model\InvoicePdf;
 use Sylius\InvoicingPlugin\Provider\InvoiceFileProviderInterface;
 
 final class InvoiceEmailSenderTest extends TestCase
 {
+    private const CUSTOMER_EMAIL = 'customer@example.com';
+
+    private const INVOICE_NUMBER = '2024/11/0001';
+
+    private const INVOICE_ID = 'INV-0001';
+
     private MockObject&SenderInterface $sender;
 
     private InvoiceFileProviderInterface&MockObject $invoiceFileProvider;
+
+    private InvoiceInterface&MockObject $invoice;
+
+    private ?string $temporaryFilePath = null;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->sender = $this->createMock(SenderInterface::class);
         $this->invoiceFileProvider = $this->createMock(InvoiceFileProviderInterface::class);
+        $this->invoice = $this->createMock(InvoiceInterface::class);
+
+        $this->invoice
+            ->method('number')
+            ->willReturn(self::INVOICE_NUMBER);
+
+        $this->invoice
+            ->method('id')
+            ->willReturn(self::INVOICE_ID);
+    }
+
+    protected function tearDown(): void
+    {
+        if (null !== $this->temporaryFilePath && file_exists($this->temporaryFilePath)) {
+            @unlink($this->temporaryFilePath);
+        }
+
+        parent::tearDown();
     }
 
     #[Test]
@@ -46,48 +78,289 @@ final class InvoiceEmailSenderTest extends TestCase
     }
 
     #[Test]
-    public function it_sends_an_invoice_to_a_given_email_address(): void
+    #[DataProvider('attemptProvider')]
+    public function it_sends_invoice_email_with_pdf_attachment(int $attempt): void
     {
         $invoiceEmailSender = new InvoiceEmailSender($this->sender, $this->invoiceFileProvider);
-        $invoice = $this->createMock(InvoiceInterface::class);
 
-        $invoicePdf = new InvoicePdf('invoice.pdf', 'CONTENT');
-        $invoicePdf->setFullPath('/path/to/invoices/invoice.pdf');
+        $temporaryPath = $this->createTemporaryPdfFile();
+        $invoicePdf = new InvoicePdf('invoice.pdf', 'PDF_CONTENT');
+        $invoicePdf->setFullPath($temporaryPath);
 
         $this->invoiceFileProvider
             ->expects(self::once())
             ->method('provide')
-            ->with($invoice)
+            ->with($this->invoice)
             ->willReturn($invoicePdf);
+
+        $this->invoice
+            ->expects(self::once())
+            ->method('setPdfSent')
+            ->with(true);
 
         $this->sender
             ->expects(self::once())
             ->method('send')
             ->with(
                 Emails::INVOICE_GENERATED,
-                ['sylius@example.com'],
-                ['invoice' => $invoice],
-                ['/path/to/invoices/invoice.pdf'],
+                [self::CUSTOMER_EMAIL],
+                ['invoice' => $this->invoice],
+                [$temporaryPath],
+                [],
+                [],
+                [],
             );
 
-        $invoiceEmailSender->sendInvoiceEmail($invoice, 'sylius@example.com');
+        $invoiceEmailSender->sendInvoiceEmail($this->invoice, self::CUSTOMER_EMAIL, $attempt);
     }
 
     #[Test]
-    public function it_sends_an_invoice_without_attachment_to_a_given_email_address(): void
+    public function it_sends_invoice_email_without_pdf_when_pdf_generation_disabled(): void
     {
         $invoiceEmailSender = new InvoiceEmailSender($this->sender, $this->invoiceFileProvider, false);
-        $invoice = $this->createMock(InvoiceInterface::class);
 
         $this->invoiceFileProvider
-            ->expects($this->never())
+            ->expects(self::never())
             ->method('provide');
+
+        $this->invoice
+            ->expects(self::never())
+            ->method('setPdfSent');
 
         $this->sender
             ->expects(self::once())
             ->method('send')
-            ->with(Emails::INVOICE_GENERATED, ['sylius@example.com'], ['invoice' => $invoice]);
+            ->with(
+                Emails::INVOICE_GENERATED,
+                [self::CUSTOMER_EMAIL],
+                ['invoice' => $this->invoice],
+                [],
+                [],
+                [],
+                [],
+            );
 
-        $invoiceEmailSender->sendInvoiceEmail($invoice, 'sylius@example.com');
+        $invoiceEmailSender->sendInvoiceEmail($this->invoice, self::CUSTOMER_EMAIL);
+    }
+
+    #[Test]
+    public function it_handles_pdf_file_not_readable_exception(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $retryScheduler = $this->createMock(InvoiceEmailRetrySchedulerInterface::class);
+
+        $invoiceEmailSender = new InvoiceEmailSender(
+            $this->sender,
+            $this->invoiceFileProvider,
+            true,
+            $logger,
+            $retryScheduler,
+        );
+
+        $invoicePdf = new InvoicePdf('invoice.pdf', 'PDF_CONTENT');
+        $invoicePdf->setFullPath('/nonexistent/path/invoice.pdf');
+
+        $this->invoiceFileProvider
+            ->expects(self::once())
+            ->method('provide')
+            ->with($this->invoice)
+            ->willReturn($invoicePdf);
+
+        $this->invoice
+            ->expects(self::once())
+            ->method('setPdfSent')
+            ->with(false);
+
+        $logger
+            ->expects(self::once())
+            ->method('error')
+            ->with(
+                sprintf(
+                    'Invoice PDF for invoice "%s" (%s) could not be generated. Email to "%s" will not be sent.',
+                    self::INVOICE_NUMBER,
+                    self::INVOICE_ID,
+                    self::CUSTOMER_EMAIL,
+                ),
+                self::callback(fn (array $context) => isset($context['exception']) && $context['exception'] instanceof InvoiceFileGenerationFailedException),
+            );
+
+        $retryScheduler
+            ->expects(self::once())
+            ->method('scheduleRetry')
+            ->with($this->invoice, self::CUSTOMER_EMAIL, 0);
+
+        $this->sender
+            ->expects(self::never())
+            ->method('send');
+
+        $invoiceEmailSender->sendInvoiceEmail($this->invoice, self::CUSTOMER_EMAIL);
+    }
+
+    #[Test]
+    public function it_schedules_retry_when_pdf_generation_fails(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $retryScheduler = $this->createMock(InvoiceEmailRetrySchedulerInterface::class);
+
+        $invoiceEmailSender = new InvoiceEmailSender(
+            $this->sender,
+            $this->invoiceFileProvider,
+            true,
+            $logger,
+            $retryScheduler,
+        );
+
+        $this->invoiceFileProvider
+            ->expects(self::once())
+            ->method('provide')
+            ->with($this->invoice)
+            ->willThrowException(InvoiceFileGenerationFailedException::occur());
+
+        $this->invoice
+            ->expects(self::once())
+            ->method('setPdfSent')
+            ->with(false);
+
+        $logger
+            ->expects(self::once())
+            ->method('error')
+            ->with(
+                sprintf(
+                    'Invoice PDF for invoice "%s" (%s) could not be generated. Email to "%s" will not be sent.',
+                    self::INVOICE_NUMBER,
+                    self::INVOICE_ID,
+                    self::CUSTOMER_EMAIL,
+                ),
+                self::callback(fn (array $context) => isset($context['exception']) && $context['exception'] instanceof InvoiceFileGenerationFailedException),
+            );
+
+        $retryScheduler
+            ->expects(self::once())
+            ->method('scheduleRetry')
+            ->with($this->invoice, self::CUSTOMER_EMAIL, 0);
+
+        $this->sender
+            ->expects(self::never())
+            ->method('send');
+
+        $invoiceEmailSender->sendInvoiceEmail($this->invoice, self::CUSTOMER_EMAIL);
+    }
+
+    #[Test]
+    public function it_handles_pdf_generation_failure_without_retry_scheduler(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $invoiceEmailSender = new InvoiceEmailSender(
+            $this->sender,
+            $this->invoiceFileProvider,
+            true,
+            $logger,
+            null,
+        );
+
+        $this->invoiceFileProvider
+            ->expects(self::once())
+            ->method('provide')
+            ->with($this->invoice)
+            ->willThrowException(InvoiceFileGenerationFailedException::occur());
+
+        $this->invoice
+            ->expects(self::once())
+            ->method('setPdfSent')
+            ->with(false);
+
+        $logger
+            ->expects(self::once())
+            ->method('error');
+
+        $this->sender
+            ->expects(self::never())
+            ->method('send');
+
+        $invoiceEmailSender->sendInvoiceEmail($this->invoice, self::CUSTOMER_EMAIL);
+    }
+
+    #[Test]
+    public function it_handles_pdf_generation_failure_without_logger(): void
+    {
+        $retryScheduler = $this->createMock(InvoiceEmailRetrySchedulerInterface::class);
+
+        $invoiceEmailSender = new InvoiceEmailSender(
+            $this->sender,
+            $this->invoiceFileProvider,
+            true,
+            null,
+            $retryScheduler,
+        );
+
+        $this->invoiceFileProvider
+            ->expects(self::once())
+            ->method('provide')
+            ->with($this->invoice)
+            ->willThrowException(InvoiceFileGenerationFailedException::occur());
+
+        $this->invoice
+            ->expects(self::once())
+            ->method('setPdfSent')
+            ->with(false);
+
+        $retryScheduler
+            ->expects(self::once())
+            ->method('scheduleRetry')
+            ->with($this->invoice, self::CUSTOMER_EMAIL, 0);
+
+        $this->sender
+            ->expects(self::never())
+            ->method('send');
+
+        $invoiceEmailSender->sendInvoiceEmail($this->invoice, self::CUSTOMER_EMAIL);
+    }
+
+    #[Test]
+    public function it_handles_pdf_generation_failure_without_logger_and_retry_scheduler(): void
+    {
+        $invoiceEmailSender = new InvoiceEmailSender(
+            $this->sender,
+            $this->invoiceFileProvider,
+            true,
+            null,
+            null,
+        );
+
+        $this->invoiceFileProvider
+            ->expects(self::once())
+            ->method('provide')
+            ->with($this->invoice)
+            ->willThrowException(InvoiceFileGenerationFailedException::occur());
+
+        $this->invoice
+            ->expects(self::once())
+            ->method('setPdfSent')
+            ->with(false);
+
+        $this->sender
+            ->expects(self::never())
+            ->method('send');
+
+        $invoiceEmailSender->sendInvoiceEmail($this->invoice, self::CUSTOMER_EMAIL);
+    }
+
+    public static function attemptProvider(): array
+    {
+        return [
+            'first attempt' => [0],
+            'second attempt' => [1],
+            'third attempt' => [2],
+        ];
+    }
+
+    private function createTemporaryPdfFile(): string
+    {
+        $this->temporaryFilePath = tempnam(sys_get_temp_dir(), 'invoice_pdf_');
+        self::assertNotFalse($this->temporaryFilePath);
+        self::assertNotFalse(file_put_contents($this->temporaryFilePath, 'PDF_CONTENT'));
+
+        return $this->temporaryFilePath;
     }
 }

--- a/tests/Unit/Entity/InvoiceTest.php
+++ b/tests/Unit/Entity/InvoiceTest.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Tests\Sylius\InvoicingPlugin\Unit\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\OrderInterface;
@@ -28,19 +30,27 @@ use Sylius\InvoicingPlugin\Entity\TaxItemInterface;
 
 final class InvoiceTest extends TestCase
 {
-    private BillingDataInterface $billingData;
+    private const ID = '7903c83a-4c5e-4bcf-81d8-9dc304c6a353';
 
-    private LineItemInterface $lineItem;
+    private const INVOICE_NUMBER = '2019/01/000000001';
 
-    private TaxItemInterface $taxItem;
+    private const CURRENCY_CODE = 'USD';
 
-    private ChannelInterface $channel;
+    private const LOCALE_CODE = 'en_US';
 
-    private InvoiceShopBillingDataInterface $shopBillingData;
+    private const TOTAL = 10300;
 
-    private OrderInterface $order;
+    private BillingDataInterface&MockObject $billingData;
 
-    private Invoice $invoice;
+    private LineItemInterface&MockObject $lineItem;
+
+    private MockObject&TaxItemInterface $taxItem;
+
+    private ChannelInterface&MockObject $channel;
+
+    private InvoiceShopBillingDataInterface&MockObject $shopBillingData;
+
+    private MockObject&OrderInterface $order;
 
     private \DateTimeImmutable $issuedAt;
 
@@ -54,58 +64,282 @@ final class InvoiceTest extends TestCase
         $this->shopBillingData = $this->createMock(InvoiceShopBillingDataInterface::class);
         $this->order = $this->createMock(OrderInterface::class);
 
-        $this->issuedAt = \DateTimeImmutable::createFromFormat('Y-m', '2019-01');
-
-        $this->lineItem->expects(self::once())
-            ->method('setInvoice')
-            ->with($this->isInstanceOf(Invoice::class));
-
-        $this->taxItem->expects(self::once())
-            ->method('setInvoice')
-            ->with($this->isInstanceOf(Invoice::class));
-
-        $this->invoice = new Invoice(
-            '7903c83a-4c5e-4bcf-81d8-9dc304c6a353',
-            $this->issuedAt->format('Y/m') . '/000000001',
-            $this->order,
-            $this->issuedAt,
-            $this->billingData,
-            'USD',
-            'en_US',
-            10300,
-            new ArrayCollection([$this->lineItem]),
-            new ArrayCollection([$this->taxItem]),
-            $this->channel,
-            InvoiceInterface::PAYMENT_STATE_COMPLETED,
-            $this->shopBillingData,
-        );
+        $issuedAt = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2019-01-15 10:30:00');
+        self::assertNotFalse($issuedAt);
+        $this->issuedAt = $issuedAt;
     }
 
     #[Test]
     public function it_implements_invoice_interface(): void
     {
-        self::assertInstanceOf(InvoiceInterface::class, $this->invoice);
+        $invoice = $this->createInvoice();
+
+        self::assertInstanceOf(InvoiceInterface::class, $invoice);
     }
 
     #[Test]
     public function it_implements_resource_interface(): void
     {
-        self::assertInstanceOf(ResourceInterface::class, $this->invoice);
+        $invoice = $this->createInvoice();
+
+        self::assertInstanceOf(ResourceInterface::class, $invoice);
     }
 
     #[Test]
-    public function it_has_data(): void
+    public function it_returns_id(): void
     {
-        self::assertSame('7903c83a-4c5e-4bcf-81d8-9dc304c6a353', $this->invoice->id());
-        self::assertSame('2019/01/000000001', $this->invoice->number());
-        self::assertSame($this->order, $this->invoice->order());
-        self::assertSame($this->billingData, $this->invoice->billingData());
-        self::assertSame('USD', $this->invoice->currencyCode());
-        self::assertSame('en_US', $this->invoice->localeCode());
-        self::assertSame(10300, $this->invoice->total());
-        self::assertEquals(new ArrayCollection([$this->lineItem]), $this->invoice->lineItems());
-        $this->assertEquals(new ArrayCollection([$this->taxItem]), $this->invoice->taxItems());
-        $this->assertSame($this->channel, $this->invoice->channel());
-        $this->assertSame($this->shopBillingData, $this->invoice->shopBillingData());
+        $invoice = $this->createInvoice();
+
+        self::assertSame(self::ID, $invoice->id());
+    }
+
+    #[Test]
+    public function it_returns_id_via_get_id_method(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame(self::ID, $invoice->getId());
+    }
+
+    #[Test]
+    public function it_returns_invoice_number(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame(self::INVOICE_NUMBER, $invoice->number());
+    }
+
+    #[Test]
+    public function it_returns_order(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame($this->order, $invoice->order());
+    }
+
+    #[Test]
+    public function it_returns_cloned_issued_at_date(): void
+    {
+        $invoice = $this->createInvoice();
+
+        $issuedAt = $invoice->issuedAt();
+
+        self::assertEquals($this->issuedAt, $issuedAt);
+        self::assertNotSame($this->issuedAt, $issuedAt);
+    }
+
+    #[Test]
+    public function it_returns_billing_data(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame($this->billingData, $invoice->billingData());
+    }
+
+    #[Test]
+    public function it_returns_currency_code(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame(self::CURRENCY_CODE, $invoice->currencyCode());
+    }
+
+    #[Test]
+    public function it_returns_locale_code(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame(self::LOCALE_CODE, $invoice->localeCode());
+    }
+
+    #[Test]
+    public function it_returns_total(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame(self::TOTAL, $invoice->total());
+    }
+
+    #[Test]
+    public function it_returns_line_items(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertEquals(new ArrayCollection([$this->lineItem]), $invoice->lineItems());
+    }
+
+    #[Test]
+    public function it_returns_tax_items(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertEquals(new ArrayCollection([$this->taxItem]), $invoice->taxItems());
+    }
+
+    #[Test]
+    public function it_returns_channel(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame($this->channel, $invoice->channel());
+    }
+
+    #[Test]
+    public function it_returns_shop_billing_data(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame($this->shopBillingData, $invoice->shopBillingData());
+    }
+
+    #[Test]
+    public function it_returns_payment_state(): void
+    {
+        $invoice = $this->createInvoice();
+
+        self::assertSame(InvoiceInterface::PAYMENT_STATE_COMPLETED, $invoice->paymentState());
+    }
+
+    #[Test]
+    #[DataProvider('subtotalDataProvider')]
+    public function it_calculates_subtotal_from_line_items(array $lineItemSubtotals, int $expectedSubtotal): void
+    {
+        $lineItems = [];
+        foreach ($lineItemSubtotals as $subtotal) {
+            $lineItem = $this->createMock(LineItemInterface::class);
+            $lineItem->method('subtotal')->willReturn($subtotal);
+            $lineItem->expects(self::once())->method('setInvoice');
+            $lineItems[] = $lineItem;
+        }
+
+        $invoice = new Invoice(
+            self::ID,
+            self::INVOICE_NUMBER,
+            $this->order,
+            $this->issuedAt,
+            $this->billingData,
+            self::CURRENCY_CODE,
+            self::LOCALE_CODE,
+            self::TOTAL,
+            new ArrayCollection($lineItems),
+            new ArrayCollection([]),
+            $this->channel,
+            InvoiceInterface::PAYMENT_STATE_COMPLETED,
+            $this->shopBillingData,
+        );
+
+        self::assertSame($expectedSubtotal, $invoice->subtotal());
+    }
+
+    #[Test]
+    #[DataProvider('taxesTotalDataProvider')]
+    public function it_calculates_taxes_total_from_line_items(array $lineItemTaxes, int $expectedTaxesTotal): void
+    {
+        $lineItems = [];
+        foreach ($lineItemTaxes as $taxTotal) {
+            $lineItem = $this->createMock(LineItemInterface::class);
+            $lineItem->method('taxTotal')->willReturn($taxTotal);
+            $lineItem->expects(self::once())->method('setInvoice');
+            $lineItems[] = $lineItem;
+        }
+
+        $invoice = new Invoice(
+            self::ID,
+            self::INVOICE_NUMBER,
+            $this->order,
+            $this->issuedAt,
+            $this->billingData,
+            self::CURRENCY_CODE,
+            self::LOCALE_CODE,
+            self::TOTAL,
+            new ArrayCollection($lineItems),
+            new ArrayCollection([]),
+            $this->channel,
+            InvoiceInterface::PAYMENT_STATE_COMPLETED,
+            $this->shopBillingData,
+        );
+
+        self::assertSame($expectedTaxesTotal, $invoice->taxesTotal());
+    }
+
+    #[Test]
+    #[DataProvider('pdfSentStatusProvider')]
+    public function it_returns_pdf_sent_status(bool $pdfSent): void
+    {
+        $invoice = $this->createInvoice($pdfSent);
+
+        self::assertSame($pdfSent, $invoice->isPdfSent());
+    }
+
+    #[Test]
+    public function it_allows_setting_pdf_sent_status(): void
+    {
+        $invoice = $this->createInvoice(false);
+
+        self::assertFalse($invoice->isPdfSent());
+
+        $invoice->setPdfSent(true);
+
+        self::assertTrue($invoice->isPdfSent());
+
+        $invoice->setPdfSent(false);
+
+        self::assertFalse($invoice->isPdfSent());
+    }
+
+    public static function subtotalDataProvider(): array
+    {
+        return [
+            'single line item' => [[1000], 1000],
+            'multiple line items' => [[1000, 2000, 1500], 4500],
+            'empty line items' => [[], 0],
+        ];
+    }
+
+    public static function taxesTotalDataProvider(): array
+    {
+        return [
+            'single line item with tax' => [[200], 200],
+            'multiple line items with taxes' => [[200, 300, 150], 650],
+            'empty line items' => [[], 0],
+        ];
+    }
+
+    public static function pdfSentStatusProvider(): array
+    {
+        return [
+            'pdf not sent by default' => [false],
+            'pdf sent' => [true],
+        ];
+    }
+
+    private function createInvoice(bool $pdfSent = false): Invoice
+    {
+        $this->lineItem
+            ->expects(self::once())
+            ->method('setInvoice')
+            ->with($this->isInstanceOf(Invoice::class));
+
+        $this->taxItem
+            ->expects(self::once())
+            ->method('setInvoice')
+            ->with($this->isInstanceOf(Invoice::class));
+
+        return new Invoice(
+            self::ID,
+            self::INVOICE_NUMBER,
+            $this->order,
+            $this->issuedAt,
+            $this->billingData,
+            self::CURRENCY_CODE,
+            self::LOCALE_CODE,
+            self::TOTAL,
+            new ArrayCollection([$this->lineItem]),
+            new ArrayCollection([$this->taxItem]),
+            $this->channel,
+            InvoiceInterface::PAYMENT_STATE_COMPLETED,
+            $this->shopBillingData,
+            $pdfSent,
+        );
     }
 }

--- a/tests/Unit/Provider/InvoiceFileProviderTest.php
+++ b/tests/Unit/Provider/InvoiceFileProviderTest.php
@@ -16,10 +16,12 @@ namespace Tests\Sylius\InvoicingPlugin\Unit\Provider;
 use Gaufrette\Exception\FileNotFound;
 use Gaufrette\File;
 use Gaufrette\FilesystemInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sylius\InvoicingPlugin\Entity\InvoiceInterface;
+use Sylius\InvoicingPlugin\Exception\InvoiceFileGenerationFailedException;
 use Sylius\InvoicingPlugin\Generator\InvoiceFileNameGeneratorInterface;
 use Sylius\InvoicingPlugin\Generator\InvoicePdfFileGeneratorInterface;
 use Sylius\InvoicingPlugin\Manager\InvoiceFileManagerInterface;
@@ -29,6 +31,12 @@ use Sylius\InvoicingPlugin\Provider\InvoiceFileProviderInterface;
 
 final class InvoiceFileProviderTest extends TestCase
 {
+    private const INVOICE_FILENAME = 'invoice_2024_11_0001.pdf';
+
+    private const INVOICES_DIRECTORY = '/path/to/invoices';
+
+    private const PDF_CONTENT = 'PDF_CONTENT';
+
     private InvoiceFileNameGeneratorInterface&MockObject $invoiceFileNameGenerator;
 
     private FilesystemInterface&MockObject $filesystem;
@@ -36,6 +44,8 @@ final class InvoiceFileProviderTest extends TestCase
     private InvoicePdfFileGeneratorInterface&MockObject $invoicePdfFileGenerator;
 
     private InvoiceFileManagerInterface&MockObject $invoiceFileManager;
+
+    private InvoiceInterface&MockObject $invoice;
 
     private InvoiceFileProvider $provider;
 
@@ -46,13 +56,14 @@ final class InvoiceFileProviderTest extends TestCase
         $this->filesystem = $this->createMock(FilesystemInterface::class);
         $this->invoicePdfFileGenerator = $this->createMock(InvoicePdfFileGeneratorInterface::class);
         $this->invoiceFileManager = $this->createMock(InvoiceFileManagerInterface::class);
+        $this->invoice = $this->createMock(InvoiceInterface::class);
 
         $this->provider = new InvoiceFileProvider(
             $this->invoiceFileNameGenerator,
             $this->filesystem,
             $this->invoicePdfFileGenerator,
             $this->invoiceFileManager,
-            '/path/to/invoices',
+            self::INVOICES_DIRECTORY,
         );
     }
 
@@ -63,72 +74,168 @@ final class InvoiceFileProviderTest extends TestCase
     }
 
     #[Test]
-    public function it_provides_invoice_file_for_invoice(): void
+    #[DataProvider('invoiceFileDataProvider')]
+    public function it_provides_existing_invoice_file_from_filesystem(string $fileName, string $content): void
     {
-        $invoice = $this->createMock(InvoiceInterface::class);
         $invoiceFile = $this->createMock(File::class);
 
         $this->invoiceFileNameGenerator
             ->expects(self::once())
             ->method('generateForPdf')
-            ->with($invoice)
-            ->willReturn('invoice.pdf');
+            ->with($this->invoice)
+            ->willReturn($fileName);
 
         $this->filesystem
             ->expects(self::once())
             ->method('get')
-            ->with('invoice.pdf')
+            ->with($fileName)
             ->willReturn($invoiceFile);
 
         $invoiceFile
             ->expects(self::once())
             ->method('getContent')
-            ->willReturn('CONTENT');
+            ->willReturn($content);
 
-        $result = $this->provider->provide($invoice);
+        $this->invoicePdfFileGenerator
+            ->expects(self::never())
+            ->method('generate');
 
-        $expected = new InvoicePdf('invoice.pdf', 'CONTENT');
-        $expected->setFullPath('/path/to/invoices/invoice.pdf');
+        $this->invoiceFileManager
+            ->expects(self::never())
+            ->method('save');
+
+        $result = $this->provider->provide($this->invoice);
+
+        $expected = $this->createExpectedInvoicePdf($fileName, $content);
 
         self::assertEquals($expected, $result);
     }
 
     #[Test]
-    public function it_generates_invoice_if_it_does_not_exist_and_provides_it(): void
+    #[DataProvider('invoiceFileDataProvider')]
+    public function it_generates_and_saves_invoice_when_file_not_found(string $fileName, string $content): void
     {
-        $invoice = $this->createMock(InvoiceInterface::class);
-
         $this->invoiceFileNameGenerator
             ->expects(self::once())
             ->method('generateForPdf')
-            ->with($invoice)
-            ->willReturn('invoice.pdf');
+            ->with($this->invoice)
+            ->willReturn($fileName);
 
         $this->filesystem
             ->expects(self::once())
             ->method('get')
-            ->with('invoice.pdf')
-            ->willThrowException(new FileNotFound('invoice.pdf'));
+            ->with($fileName)
+            ->willThrowException(new FileNotFound($fileName));
 
-        $invoicePdf = new InvoicePdf('invoice.pdf', 'CONTENT');
-        $invoicePdf->setFullPath('/path/to/invoices/invoice.pdf');
+        $generatedInvoicePdf = new InvoicePdf($fileName, $content);
 
         $this->invoicePdfFileGenerator
             ->expects(self::once())
             ->method('generate')
-            ->with($invoice)
-            ->willReturn($invoicePdf);
+            ->with($this->invoice)
+            ->willReturn($generatedInvoicePdf);
 
         $this->invoiceFileManager
             ->expects(self::once())
             ->method('save')
-            ->with($invoicePdf);
+            ->with($generatedInvoicePdf);
 
-        $result = $this->provider->provide($invoice);
+        $result = $this->provider->provide($this->invoice);
 
-        $expected = new InvoicePdf('invoice.pdf', 'CONTENT');
-        $expected->setFullPath('/path/to/invoices/invoice.pdf');
+        $expected = $this->createExpectedInvoicePdf($fileName, $content);
 
         self::assertEquals($expected, $result);
+    }
+
+    #[Test]
+    #[DataProvider('generationExceptionProvider')]
+    public function it_throws_invoice_file_generation_failed_exception_when_generation_fails(\Throwable $exception): void
+    {
+        $this->expectException(InvoiceFileGenerationFailedException::class);
+
+        $this->expectInvoiceFileNameGeneration();
+
+        $this->filesystem
+            ->expects(self::once())
+            ->method('get')
+            ->with(self::INVOICE_FILENAME)
+            ->willThrowException(new FileNotFound(self::INVOICE_FILENAME));
+
+        $this->invoicePdfFileGenerator
+            ->expects(self::once())
+            ->method('generate')
+            ->with($this->invoice)
+            ->willThrowException($exception);
+
+        $this->invoiceFileManager
+            ->expects(self::never())
+            ->method('save');
+
+        $this->provider->provide($this->invoice);
+    }
+
+    #[Test]
+    public function it_throws_invoice_file_generation_failed_exception_when_save_fails(): void
+    {
+        $this->expectException(InvoiceFileGenerationFailedException::class);
+
+        $this->expectInvoiceFileNameGeneration();
+
+        $this->filesystem
+            ->expects(self::once())
+            ->method('get')
+            ->with(self::INVOICE_FILENAME)
+            ->willThrowException(new FileNotFound(self::INVOICE_FILENAME));
+
+        $generatedInvoicePdf = new InvoicePdf(self::INVOICE_FILENAME, self::PDF_CONTENT);
+
+        $this->invoicePdfFileGenerator
+            ->expects(self::once())
+            ->method('generate')
+            ->with($this->invoice)
+            ->willReturn($generatedInvoicePdf);
+
+        $this->invoiceFileManager
+            ->expects(self::once())
+            ->method('save')
+            ->with($generatedInvoicePdf)
+            ->willThrowException(new \RuntimeException('Failed to save file'));
+
+        $this->provider->provide($this->invoice);
+    }
+
+    public static function invoiceFileDataProvider(): array
+    {
+        return [
+            'standard filename and content' => ['invoice_2024_11_0001.pdf', 'PDF_CONTENT'],
+            'custom filename' => ['custom_invoice.pdf', 'CUSTOM_CONTENT'],
+            'filename with special chars' => ['invoice-special_#123.pdf', 'SPECIAL_CONTENT'],
+        ];
+    }
+
+    public static function generationExceptionProvider(): array
+    {
+        return [
+            'RuntimeException' => [new \RuntimeException('Failed to generate PDF')],
+            'InvalidArgumentException' => [new \InvalidArgumentException('Invalid template')],
+            'LogicException' => [new \LogicException('Logic error in generation')],
+        ];
+    }
+
+    private function expectInvoiceFileNameGeneration(): void
+    {
+        $this->invoiceFileNameGenerator
+            ->expects(self::once())
+            ->method('generateForPdf')
+            ->with($this->invoice)
+            ->willReturn(self::INVOICE_FILENAME);
+    }
+
+    private function createExpectedInvoicePdf(string $fileName = self::INVOICE_FILENAME, string $content = self::PDF_CONTENT): InvoicePdf
+    {
+        $invoicePdf = new InvoicePdf($fileName, $content);
+        $invoicePdf->setFullPath(self::INVOICES_DIRECTORY . '/' . $fileName);
+
+        return $invoicePdf;
     }
 }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.1
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | https://github.com/Sylius/InvoicingPlugin/issues/127
| License         | MIT

 This PR adds the ability to automatically retry sending invoice emails when PDF generation fails, implementing a configurable retry mechanism with a maximum of 3 attempts and
  60-second delays between retries
