### PR TITLE
Isolate plugin messaging: Introduce dedicated event & command buses for InvoicingPlugin

### DIFF
--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+### v3.0.0 (2025-10-22)
+
+- [#397](https://github.com/Sylius/InvoicingPlugin/pull/397) Isolate plugin messaging: Introduce dedicated event & command buses for InvoicingPlugin ([@tomkalon](https://github.com/tomkalon))

--- a/UPGRADE-3.0.md
+++ b/UPGRADE-3.0.md
@@ -1,0 +1,21 @@
+# UPGRADE FROM 2.1 TO 3.0
+
+## Changes
+
+1. Introduced plugin-specific Messenger buses (`sylius_invoicing.command_bus` and `sylius_invoicing.event_bus`):
+
+- The Invoicing Plugin no longer uses the global `sylius.command_bus` or `sylius.event_bus`.
+- If you have custom message handlers, middleware, or routing related to the plugin, update them to use the new plugin-specific buses.
+- Example configuration:
+
+```yaml
+framework:
+    messenger:
+        buses:
+            sylius_invoicing.command_bus:
+                middleware:
+                    - 'validation'
+                    - 'doctrine_transaction'
+            sylius_invoicing.event_bus:
+                default_middleware: allow_no_handlers
+```

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -114,9 +114,9 @@ sylius_grid:
 framework:
     messenger:
         buses:
-            sylius.event_bus:
+            sylius_invoicing.event_bus:
                 default_middleware: allow_no_handlers
-            sylius.command_bus:
+            sylius_invoicing.command_bus:
                 middleware:
                     - 'validation'
                     - 'doctrine_transaction'

--- a/config/services.xml
+++ b/config/services.xml
@@ -37,7 +37,7 @@
             <argument type="service" id="sylius_invoicing.repository.invoice" />
             <argument type="service" id="sylius.repository.order" />
             <argument type="service" id="sylius_invoicing.email.invoice_email_sender" />
-            <tag name="messenger.message_handler" />
+            <tag name="messenger.message_handler" bus="sylius_invoicing.command_bus"/>
         </service>
 
         <service id="sylius_invoicing.security.voter.invoice" class="Sylius\InvoicingPlugin\Security\Voter\InvoiceVoter">

--- a/config/services/listeners.xml
+++ b/config/services/listeners.xml
@@ -20,26 +20,26 @@
         <defaults public="true" />
 
         <service id="sylius_invoicing.event_producer.order_payment_paid" class="Sylius\InvoicingPlugin\EventProducer\OrderPaymentPaidProducer">
-            <argument type="service" id="sylius.event_bus" />
+            <argument type="service" id="sylius_invoicing.event_bus" />
             <argument type="service" id="clock" />
             <argument type="service" id="sylius_invoicing.repository.invoice" />
         </service>
 
         <service id="sylius_invoicing.listener.order_placed" class="Sylius\InvoicingPlugin\EventListener\CreateInvoiceOnOrderPlacedListener">
             <argument type="service" id="sylius_invoicing.creator.invoice" />
-            <tag name="messenger.message_handler" bus="sylius.event_bus" />
+            <tag name="messenger.message_handler" bus="sylius_invoicing.event_bus" />
         </service>
 
         <service id="sylius_invoicing.event_producer.order_placed" class="Sylius\InvoicingPlugin\EventProducer\OrderPlacedProducer">
-            <argument type="service" id="sylius.event_bus" />
+            <argument type="service" id="sylius_invoicing.event_bus" />
             <argument type="service" id="clock" />
             <tag name="doctrine.event_listener" event="postPersist" />
             <tag name="doctrine.event_listener" event="postUpdate" />
         </service>
 
         <service id="sylius_invoicing.listener.order_payment_paid" class="Sylius\InvoicingPlugin\EventListener\OrderPaymentPaidListener">
-            <argument type="service" id="sylius.command_bus" />
-            <tag name="messenger.message_handler" bus="sylius.event_bus" />
+            <argument type="service" id="sylius_invoicing.command_bus" />
+            <tag name="messenger.message_handler" bus="sylius_invoicing.event_bus" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 3.0
| Bug fix?        | no
| New feature?    | yes
| BC breaks?      | yes
| Related tickets | https://github.com/Sylius/InvoicingPlugin/issues/157
| License         | MIT

Isolate plugin messaging: Introduce dedicated event & command buses for InvoicingPlugin