### PR TITLE
Solves the problem of generating invoices when placing an order.

### DIFF
--- a/src/Creator/InvoiceCreator.php
+++ b/src/Creator/InvoiceCreator.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sylius\InvoicingPlugin\Creator;
 
-use Doctrine\ORM\Exception\ORMException;
 use Sylius\Component\Core\Model\OrderInterface;
 use Sylius\Component\Core\Repository\OrderRepositoryInterface;
 use Sylius\InvoicingPlugin\Doctrine\ORM\InvoiceRepositoryInterface;
@@ -49,19 +48,13 @@ final class InvoiceCreator implements InvoiceCreatorInterface
 
         $invoice = $this->invoiceGenerator->generateForOrder($order, $dateTime);
 
-        if (!$this->hasEnabledPdfFileGenerator) {
-            $this->invoiceRepository->add($invoice);
+        $this->invoiceRepository->add($invoice);
 
+        if (!$this->hasEnabledPdfFileGenerator) {
             return;
         }
 
         $invoicePdf = $this->invoicePdfFileGenerator->generate($invoice);
         $this->invoiceFileManager->save($invoicePdf);
-
-        try {
-            $this->invoiceRepository->add($invoice);
-        } catch (ORMException) {
-            $this->invoiceFileManager->remove($invoicePdf);
-        }
     }
 }

--- a/tests/Unit/Creator/InvoiceCreatorTest.php
+++ b/tests/Unit/Creator/InvoiceCreatorTest.php
@@ -163,57 +163,6 @@ final class InvoiceCreatorTest extends TestCase
     }
 
     #[Test]
-    public function it_removes_saved_invoice_file_if_database_update_fails(): void
-    {
-        $order = $this->createMock(OrderInterface::class);
-        $invoice = $this->createMock(InvoiceInterface::class);
-        $invoicePdf = new InvoicePdf('invoice.pdf', 'CONTENT');
-        $invoiceDateTime = new \DateTimeImmutable('2019-02-25');
-
-        $this->orderRepository
-            ->expects(self::once())
-            ->method('findOneByNumber')
-            ->with('0000001')
-            ->willReturn($order);
-
-        $this->invoiceRepository
-            ->expects(self::once())
-            ->method('findOneByOrder')
-            ->with($order)
-            ->willReturn(null);
-
-        $this->invoiceGenerator
-            ->expects(self::once())
-            ->method('generateForOrder')
-            ->with($order, $invoiceDateTime)
-            ->willReturn($invoice);
-
-        $this->invoicePdfFileGenerator
-            ->expects(self::once())
-            ->method('generate')
-            ->with($invoice)
-            ->willReturn($invoicePdf);
-
-        $this->invoiceFileManager
-            ->expects(self::once())
-            ->method('save')
-            ->with($invoicePdf);
-
-        $this->invoiceRepository
-            ->expects(self::once())
-            ->method('add')
-            ->with($invoice)
-            ->willThrowException(new EntityNotFoundException());
-
-        $this->invoiceFileManager
-            ->expects(self::once())
-            ->method('remove')
-            ->with($invoicePdf);
-
-        ($this->creator)('0000001', $invoiceDateTime);
-    }
-
-    #[Test]
     public function it_throws_an_exception_when_invoice_was_already_created_for_given_order(): void
     {
         $order = $this->createMock(OrderInterface::class);


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 2.0
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Related tickets | https://github.com/Sylius/InvoicingPlugin/issues/127
| License         | MIT

It solves one problem, but it can generate others. This happens when the plugin is modified.
Example scenario:

- The customer places an order.
- An invoice record with a specific number is added.
- No PDF is generated because a PDF with that name already exists.
- The user has access to the invoice that was generated earlier. Perhaps it is someone else's invoice.

Here, this problem has been solved, but it involves a fairly radical change in structure: https://github.com/Sylius/InvoicingPlugin/pull/398