### PR TITLE
[CI] Remove Symfony ~7.2 from build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
 
                     -
                         php: "8.3"
-                        symfony: "~7.2.0"
+                        symfony: "~7.3.0"
                         sylius: "~2.1.0"
                         node: "24.x"
                         database: "mysql"


### PR DESCRIPTION
Removes Symfony ~7.2 build configuration from CI workflow and adds build with disabled wkhtmltopdf.

- Removed PHP 8.3 + Symfony ~7.2.0 + Sylius ~2.1.0 build configuration from the matrix
- Added PHP 8.3 + Symfony ~7.3.0 + Sylius ~2.1.0 build with `wkhtmltopdf: false` to maintain test coverage for PDF generation disabled scenario
- Build matrix now includes Symfony ^6.4 and ~7.3.0