### PR TITLE
[CI] Add 1.1 branch to upmerge workflow

### DIFF
--- a/.github/workflows/upmerge_pr.yaml
+++ b/.github/workflows/upmerge_pr.yaml
@@ -22,6 +22,9 @@ jobs:
                 include:
                     -
                         base_branch: "1.0"
+                        target_branch: "1.1"
+                    -
+                        base_branch: "1.1"
                         target_branch: "2.0"
                     -
                         base_branch: "2.0"


### PR DESCRIPTION
Adds `1.1` branch to the upmerge workflow configuration.

Changes:
- Add `1.0` → `1.1` upmerge step
- Update matrix to include the new version branch