### PR TITLE
Add filtering cve related with APIP

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -216,7 +216,7 @@ jobs:
 
             -
                 name: Run security check
-                run: symfony security:check
+                run: composer audit --abandoned=ignore
 
             -
                 name: Run PHPStan

--- a/AUDIT-IGNORE.md
+++ b/AUDIT-IGNORE.md
@@ -1,0 +1,11 @@
+# AUDIT-IGNORE
+
+This document explains why specific advisories are added to `composer.json` → `config.audit.ignore`.
+
+**PKSA-gs8r-6kz6-pp56** — `api-platform/core` CVE-2025-31485; affected versions < 3.4.17, 4.0.0–4.0.21, 4.1.0–4.1.4 are pulled by Sylius dependency constraints. GraphQL property security grant caching issue allows unauthorized access.
+https://www.cve.org/CVERecord?id=CVE-2025-31485
+
+**PKSA-gnn4-pxdg-q76m** — `api-platform/core` CVE-2025-31481; same affected versions as above. GraphQL security bypass via Relay `node` type allows unauthorized entity access.
+https://www.cve.org/CVERecord?id=CVE-2025-31481
+
+**PKSA-4g5g-4rkv-myqs** — PKSA-4g5g-4rkv-myqs

--- a/AUDIT-IGNORE.md
+++ b/AUDIT-IGNORE.md
@@ -8,4 +8,14 @@ https://www.cve.org/CVERecord?id=CVE-2025-31485
 **PKSA-gnn4-pxdg-q76m** — `api-platform/core` CVE-2025-31481; same affected versions as above. GraphQL security bypass via Relay `node` type allows unauthorized entity access.
 https://www.cve.org/CVERecord?id=CVE-2025-31481
 
-**PKSA-4g5g-4rkv-myqs** — PKSA-4g5g-4rkv-myqs
+**PKSA-yhcn-xrg3-68b1** — `twig/twig` CVE-2024-45411; affected versions < 1.44.8, < 2.16.1, < 3.14.0 are pulled by Sylius dependency constraints. Sandbox security checks can be bypassed when templates are loaded in non-sandbox context before include().
+https://www.cve.org/CVERecord?id=CVE-2024-45411
+
+**PKSA-2wrf-1xmk-1pky** — `twig/twig` CVE-2024-51755; affected versions < 3.11.2 or 3.12.0–3.14.0 are pulled by Sylius dependency constraints. Unguarded `__isset()` and array-access in sandbox allows attribute access on Array-like objects.
+https://www.cve.org/CVERecord?id=CVE-2024-51755
+
+**PKSA-365x-2zjk-pt47** — `symfony/http-foundation` CVE-2025-64500; affected versions < 5.4.50, < 6.4.29, < 7.3.7 are pulled by Sylius dependency constraints. Incorrect parsing of PATH_INFO can lead to limited authorization bypass.
+https://www.cve.org/CVERecord?id=CVE-2025-64500
+
+**PKSA-4g5g-4rkv-myqs** — `enshrined/svg-sanitize` CVE-2025-55166; affected versions < 0.22.0 are pulled by Sylius 1.13.x dependency constraints (requires ^0.16). Attribute sanitization bypass allowing XSS via mixed-case attributes. Fixed in Sylius 1.14 by removing the dependency entirely.
+https://www.cve.org/CVERecord?id=CVE-2025-55166

--- a/composer.json
+++ b/composer.json
@@ -79,6 +79,13 @@
             "phpstan/extension-installer": true,
             "symfony/flex": true,
             "symfony/thanks": false
+        },
+        "audit": {
+          "ignore": [
+            "PKSA-gs8r-6kz6-pp56",
+            "PKSA-gnn4-pxdg-q76m",
+            "PKSA-4g5g-4rkv-myqs"
+          ]
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,9 @@
           "ignore": [
             "PKSA-gs8r-6kz6-pp56",
             "PKSA-gnn4-pxdg-q76m",
+            "PKSA-yhcn-xrg3-68b1",
+            "PKSA-2wrf-1xmk-1pky",
+            "PKSA-365x-2zjk-pt47",
             "PKSA-4g5g-4rkv-myqs"
           ]
         }


### PR DESCRIPTION
| Q               | A
|-----------------|-----
| Branch?         | 1.0
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | 
| License         | MIT

## Summary

Fix CI build by adding CVE filtering to composer audit ignore list and updating security check workflow.

## Changes

1. **composer.json** - Added CVE advisories to `config.audit.ignore`:
   - `PKSA-gs8r-6kz6-pp56` (api-platform/core CVE-2025-31485)
   - `PKSA-gnn4-pxdg-q76m` (api-platform/core CVE-2025-31481)
   - `PKSA-yhcn-xrg3-68b1` (twig/twig CVE-2024-45411)
   - `PKSA-2wrf-1xmk-1pky` (twig/twig CVE-2024-51755)
   - `PKSA-365x-2zjk-pt47` (symfony/http-foundation CVE-2025-64500)

2. **AUDIT-IGNORE.md** - Created documentation file explaining why each CVE is ignored (following pattern from Sylius/Sylius#18553)

3. **build.yaml** - Changed security check command from `symfony security:check` to `composer audit --locked --abandoned=ignore`

## Why switch from `symfony security:check` to `composer audit`?

**Official Symfony documentation recommends `composer audit` for CI:**
> "In continuous integration services you can check security vulnerabilities by running the `composer audit` command."
> 
> Source: https://symfony.com/doc/current/setup.html#checking-security-vulnerabilities

**Key advantages:**
- ✅ `composer audit` respects ignore configuration in `composer.json` 
- ✅ Built into Composer 2.4+ - no need to install Symfony CLI in CI
- ✅ Allows selective ignoring of specific CVEs with justification
- ❌ `symfony security:check` has NO support for ignore configuration
- ❌ Would require `continue-on-error: true` (ignores ALL errors, not just known CVEs)

Following the same approach as:
- https://github.com/Sylius/Sylius/pull/18553
- https://github.com/Sylius/Sylius/pull/18549
- https://github.com/Sylius/AdyenPlugin/pull/172