### PR TITLE
Add telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,3 +155,8 @@ More instructions on the [fixtures configuration instructions](docs/fixtures.md)
 
 If you think that you have found a security issue, please do not use the issue tracker and do not post it publicly.
 Instead, all security issues must be sent to `security@sylius.com`.
+
+## Telemetry
+
+This plugin enforces telemetry data collection when used with Sylius.
+Details are described in [TELEMETRY_POLICY.md](./TELEMETRY_POLICY.md).

--- a/TELEMETRY_POLICY.md
+++ b/TELEMETRY_POLICY.md
@@ -1,0 +1,69 @@
+# Telemetry Policy
+
+## Applicability
+
+This Telemetry Policy applies to the use of this plugin in combination with Sylius.
+
+By installing or using this plugin with Sylius, the user acknowledges that telemetry data is collected and transmitted as described in this document.
+
+---
+
+## Mandatory telemetry
+
+Telemetry data collection is mandatory when this plugin is used.
+
+While this plugin is installed and active, Sylius telemetry operates under the conditions defined by this plugin and cannot be disabled independently.
+Telemetry behavior outside of this scope follows the standard Sylius configuration.
+
+---
+
+## Scope of collected data
+
+Telemetry is limited to non-identifying technical data, which may include:
+
+- Sylius version
+- plugin version
+- PHP version and selected dependency versions
+- identifiers of installed and enabled plugins
+- runtime environment classification (production or non-production)
+
+Telemetry does not include, and is not intended to include:
+
+- personal data
+- customer data
+- order data
+- product data
+- business, transactional, or confidential information
+- authentication credentials or secrets
+
+A detailed description of the Sylius telemetry mechanism is available in the public issue:
+https://github.com/Sylius/Sylius/issues/18588
+
+---
+
+## Purpose and use of telemetry data
+
+Telemetry data is collected for the purpose of:
+
+- understanding usage patterns within the Sylius ecosystem
+- analyzing the adoption and frequency of plugin usage
+- identifying commonly used versions of Sylius and plugins
+- supporting maintenance, compatibility, and future development efforts
+
+Telemetry data is processed in aggregated form and is not used to identify individual users, installations, or businesses.
+
+---
+
+## Licensing
+
+This plugin is distributed under the MIT license.
+
+Telemetry collection constitutes part of the technical operation of the software and does not alter, restrict, or supplement the rights granted under the license.
+
+---
+
+## Changes to this policy
+
+This Telemetry Policy may be updated to reflect changes in telemetry implementation, legal requirements, or operational practices.
+
+Updated versions of this policy will be made available in the plugin repository.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,13 @@
 {
     "name": "sylius/invoicing-plugin",
     "type": "sylius-plugin",
-    "keywords": ["sylius", "sylius-plugin", "symfony", "e-commerce", "invoicing"],
+    "keywords": [
+        "sylius",
+        "sylius-plugin",
+        "symfony",
+        "e-commerce",
+        "invoicing"
+    ],
     "description": "Invoicing plugin for Sylius.",
     "license": "MIT",
     "require": {
@@ -11,6 +17,7 @@
         "sylius/grid-bundle": "^1.9",
         "sylius/resource-bundle": "^1.9",
         "sylius/sylius": "~1.14.0",
+        "sylius/telemetry": "^1.0",
         "symfony/clock": "^6.4",
         "symfony/config": "^5.4.21 || ^6.4",
         "symfony/dependency-injection": "^5.4.21 || ^6.4",
@@ -82,19 +89,19 @@
             "symfony/thanks": false
         },
         "audit": {
-          "ignore": [
-            "PKSA-gs8r-6kz6-pp56",
-            "PKSA-gnn4-pxdg-q76m",
-            "PKSA-yhcn-xrg3-68b1",
-            "PKSA-2wrf-1xmk-1pky",
-            "PKSA-365x-2zjk-pt47",
-            "PKSA-4g5g-4rkv-myqs"
-          ]
+            "ignore": [
+                "PKSA-gs8r-6kz6-pp56",
+                "PKSA-gnn4-pxdg-q76m",
+                "PKSA-yhcn-xrg3-68b1",
+                "PKSA-2wrf-1xmk-1pky",
+                "PKSA-365x-2zjk-pt47",
+                "PKSA-4g5g-4rkv-myqs"
+            ]
         }
     },
     "extra": {
         "branch-alias": {
-            "dev-1.0": "1.0-dev"
+            "dev-1.1": "1.1-dev"
         },
         "public-dir": "vendor/sylius/test-application/public"
     },

--- a/src/SyliusInvoicingPlugin.php
+++ b/src/SyliusInvoicingPlugin.php
@@ -15,6 +15,7 @@ namespace Sylius\InvoicingPlugin;
 
 use Sylius\Bundle\CoreBundle\Application\SyliusPluginTrait;
 use Sylius\InvoicingPlugin\DependencyInjection\Compiler\SymfonyClockCompilerPass;
+use Sylius\Telemetry\TelemetryCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -27,6 +28,7 @@ final class SyliusInvoicingPlugin extends Bundle
         parent::build($container);
 
         $container->addCompilerPass(new SymfonyClockCompilerPass());
+        $container->addCompilerPass(new TelemetryCompilerPass());
     }
 
     public function getPath(): string


### PR DESCRIPTION
Adds telemetry policy and `sylius/telemetry-bundle` as a hard dependency.

- `TELEMETRY_POLICY.md` — describes scope, purpose, and conditions of telemetry data collection
- `composer.json` — requires `sylius/telemetry-bundle: ^1.0`
- `README.md` — telemetry notice pointing to the policy file

Related: https://github.com/Sylius/Sylius/issues/18588